### PR TITLE
feat(api): add /logs/recent and /logs/metrics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ npm run dev
 - `POST /v1/chat/completions`
 - `POST /v1/debate`
 - `POST /analyze/logs`
+- `GET /logs/recent`
+- `GET /logs/metrics`
 - `GET /healthz`
 
 ## Envelope Contract
@@ -93,6 +95,7 @@ Security controls:
 - `ALLOWED_LOG_FILES` (comma-separated absolute files for `source: "file"` in `/analyze/logs`)
 - `DEBATE_MODEL_ALLOWLIST` (comma-separated model IDs allowed for `/v1/debate`)
 - `DEBATE_MAX_CONCURRENT` (default `1`; max active `/v1/debate` requests)
+- `LOG_BUFFER_MAX_ENTRIES` (default `2000`; in-memory API log buffer size for `/logs/*`)
 
 ## Quick Tests
 Streaming CHAT:
@@ -163,6 +166,16 @@ curl -sS http://127.0.0.1:3000/analyze/logs \
     "hours": 6,
     "maxLines": 300
   }'
+```
+
+Recent API logs:
+```bash
+curl -sS "http://127.0.0.1:3000/logs/recent?limit=100"
+```
+
+API metrics (last 1 hour):
+```bash
+curl -sS "http://127.0.0.1:3000/logs/metrics?window=1h"
 ```
 
 ## OpenClaw Provider Setup

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,6 +1,16 @@
 type LogLevel = 'debug' | 'info';
+type LogLevelWithError = LogLevel | 'error';
+
+type LogEntry = {
+  ts: string;
+  level: LogLevelWithError;
+  msg: string;
+  fields: Record<string, unknown>;
+};
 
 const level: LogLevel = process.env.LOG_LEVEL === 'debug' ? 'debug' : 'info';
+const maxLogBufferEntries = Number(process.env.LOG_BUFFER_MAX_ENTRIES ?? 2000);
+const logBuffer: LogEntry[] = [];
 
 function shouldLog(msgLevel: LogLevel): boolean {
   if (level === 'debug') {
@@ -10,18 +20,94 @@ function shouldLog(msgLevel: LogLevel): boolean {
 }
 
 function baseLog(msgLevel: LogLevel, message: string, fields: Record<string, unknown> = {}): void {
+  const ts = new Date().toISOString();
+  pushLogEntry({
+    ts,
+    level: msgLevel,
+    msg: message,
+    fields
+  });
+
   if (!shouldLog(msgLevel)) {
     return;
   }
 
   const payload = {
-    ts: new Date().toISOString(),
+    ts,
     level: msgLevel,
     msg: message,
     ...fields
   };
 
   process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+function pushLogEntry(entry: LogEntry): void {
+  logBuffer.push(entry);
+  while (logBuffer.length > maxLogBufferEntries) {
+    logBuffer.shift();
+  }
+}
+
+function parseWindowMs(raw: string | undefined): number {
+  if (!raw) {
+    return 60 * 60 * 1000;
+  }
+
+  const trimmed = raw.trim().toLowerCase();
+  const match = /^(\d+)([smhd])$/.exec(trimmed);
+  if (!match) {
+    return 60 * 60 * 1000;
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2];
+  const multiplier =
+    unit === 's' ? 1000 :
+      unit === 'm' ? 60 * 1000 :
+        unit === 'h' ? 60 * 60 * 1000 :
+          24 * 60 * 60 * 1000;
+
+  return value * multiplier;
+}
+
+export function getRecentLogs(limit = 100): LogEntry[] {
+  const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(Math.floor(limit), 1000)) : 100;
+  return logBuffer.slice(-safeLimit);
+}
+
+export function getLogMetrics(windowRaw: string | undefined): {
+  window: string;
+  windowMs: number;
+  total: number;
+  byLevel: Record<LogLevelWithError, number>;
+  byMessage: Record<string, number>;
+} {
+  const window = windowRaw?.trim() ? windowRaw.trim() : '1h';
+  const windowMs = parseWindowMs(windowRaw);
+  const sinceTs = Date.now() - windowMs;
+  const byLevel: Record<LogLevelWithError, number> = { debug: 0, info: 0, error: 0 };
+  const byMessage: Record<string, number> = {};
+  let total = 0;
+
+  for (const entry of logBuffer) {
+    const ts = Date.parse(entry.ts);
+    if (Number.isNaN(ts) || ts < sinceTs) {
+      continue;
+    }
+
+    total += 1;
+    byLevel[entry.level] += 1;
+    byMessage[entry.msg] = (byMessage[entry.msg] ?? 0) + 1;
+  }
+
+  return {
+    window,
+    windowMs,
+    total,
+    byLevel,
+    byMessage
+  };
 }
 
 export const log = {
@@ -32,8 +118,16 @@ export const log = {
     baseLog('info', message, fields);
   },
   error: (message: string, fields: Record<string, unknown> = {}): void => {
+    const ts = new Date().toISOString();
+    pushLogEntry({
+      ts,
+      level: 'error',
+      msg: message,
+      fields
+    });
+
     const payload = {
-      ts: new Date().toISOString(),
+      ts,
       level: 'error',
       msg: message,
       ...fields

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { DebateInputError, runDebate } from './debate.js';
 import { chooseChatModel } from './router.js';
 import { ChatCompletionRequestSchema, DebateRequestSchema } from './schema.js';
 import { ollamaBaseURL, runWorkerText, runWorkerTextStream } from './ollama.js';
-import { log } from './log.js';
+import { getLogMetrics, getRecentLogs, log } from './log.js';
 import { sanitizeLLMOutput } from './sanitize.js';
 import { registerLogExplainerRoutes } from './logExplainer/route.js';
 
@@ -379,6 +379,28 @@ app.get('/v1/debate/schema', (_req: Request, res: Response) => {
 
 app.get('/healthz', (_req: Request, res: Response) => {
   res.status(200).json({ ok: true });
+});
+
+app.get('/logs/recent', (req: Request, res: Response) => {
+  const limitRaw = String(req.query.limit ?? '100');
+  const limit = Number.parseInt(limitRaw, 10);
+  const logs = getRecentLogs(Number.isNaN(limit) ? 100 : limit);
+
+  res.status(200).json({
+    ok: true,
+    count: logs.length,
+    logs
+  });
+});
+
+app.get('/logs/metrics', (req: Request, res: Response) => {
+  const window = typeof req.query.window === 'string' ? req.query.window : undefined;
+  const metrics = getLogMetrics(window);
+
+  res.status(200).json({
+    ok: true,
+    ...metrics
+  });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- add read-only API log observability endpoints for OpenClaw and operators
- add bounded in-memory request log buffer with configurable size
- expose aggregated log metrics over a query window
- document endpoint usage and new env var in README

## Changes
- `src/log.ts`
  - add in-memory ring buffer for emitted logs (`LOG_BUFFER_MAX_ENTRIES`, default `2000`)
  - add `getRecentLogs(limit)` helper (hard-capped to 1000)
  - add `getLogMetrics(window)` helper supporting `s|m|h|d` windows (default `1h`)
- `src/server.ts`
  - add `GET /logs/recent?limit=100`
  - add `GET /logs/metrics?window=1h`
- `README.md`
  - list new endpoints and env var
  - add curl examples

## Safety
- read-only endpoints only
- no shell execution, no file writes, no privilege changes
- metrics/read APIs consume in-memory data only

## Validation
- `npm run build` passes

## Example calls
```bash
curl -sS "http://192.168.1.130:3000/logs/recent?limit=50"
curl -sS "http://192.168.1.130:3000/logs/metrics?window=1h"
```
