### PR TITLE
feat(versioning): add runtime version endpoint and response header

### DIFF
--- a/OPENCLAW_KT_LOG_OBSERVABILITY.md
+++ b/OPENCLAW_KT_LOG_OBSERVABILITY.md
@@ -1,0 +1,106 @@
+# KT: OpenClaw -> BlackIce Log + Observability API
+
+## Goal
+Let OpenClaw use BlackIce only through HTTP (no SSH, no file access), with:
+- target discovery
+- single-log analysis
+- batch analysis
+- incremental analysis
+- router observability (`/logs/recent`, `/logs/metrics`)
+
+Base URL:
+`http://192.168.1.130:3000`
+
+## Required Call Order
+1. `GET /analyze/logs/targets`
+2. Use returned targets in analysis calls
+3. Prefer `POST /analyze/logs/batch` for broad checks
+4. Use `POST /analyze/logs/incremental` for polling/follow-ups
+5. Use `/logs/*` endpoints for router health visibility
+
+## Endpoints
+
+### 1) Discover approved file targets
+```bash
+curl -sS http://192.168.1.130:3000/analyze/logs/targets
+```
+
+### 2) Service status + limits
+```bash
+curl -sS http://192.168.1.130:3000/analyze/logs/status
+```
+
+### 3) Machine-readable metadata/schemas
+```bash
+curl -sS http://192.168.1.130:3000/analyze/logs/metadata
+```
+
+### 4) Analyze one target
+```bash
+curl -sS http://192.168.1.130:3000/analyze/logs \
+  -H 'Content-Type: application/json' \
+  -d '{"source":"file","target":"/var/log/remote/paperless-ngx.log","hours":6,"maxLines":300}'
+```
+
+### 5) Analyze all/some targets in one call
+```bash
+curl -sS http://192.168.1.130:3000/analyze/logs/batch \
+  -H 'Content-Type: application/json' \
+  -d '{"source":"file","hours":6,"maxLines":300,"concurrency":2}'
+```
+
+### 6) Incremental analysis (new lines only)
+```bash
+curl -sS http://192.168.1.130:3000/analyze/logs/incremental \
+  -H 'Content-Type: application/json' \
+  -d '{"source":"file","target":"/var/log/remote/paperless-ngx.log","cursor":0,"hours":6,"maxLines":300}'
+```
+
+### 7) Recent router/API logs
+```bash
+curl -sS "http://192.168.1.130:3000/logs/recent?limit=100"
+```
+
+### 8) Router/API metrics
+```bash
+curl -sS "http://192.168.1.130:3000/logs/metrics?window=1h"
+```
+
+### 9) Running version/build info
+```bash
+curl -sS "http://192.168.1.130:3000/version"
+```
+
+## Error Handling Contract (important)
+
+For batch result rows:
+```json
+{
+  "target": "/var/log/remote/docker.log",
+  "ok": false,
+  "status": 422,
+  "error": "No logs were collected for the given query"
+}
+```
+
+OpenClaw rules:
+1. Do not fail whole workflow when one batch row has `ok:false`.
+2. Report per-target failures separately.
+3. Retry only transient cases (timeouts/5xx), not validation errors.
+
+## Safety Notes
+1. BlackIce is read-only for log analysis.
+2. Never execute remediation commands from model output.
+3. If response includes redaction/safety indicators, display them as warnings, not failures.
+
+## Minimal OpenClaw Prompt Snippet
+Use this as the integration instruction:
+
+```text
+Use BlackIce at http://192.168.1.130:3000 for log diagnostics.
+Always call GET /analyze/logs/targets first and only use returned targets.
+Use POST /analyze/logs/batch for broad checks, POST /analyze/logs for focused checks, and POST /analyze/logs/incremental for follow-up polling.
+Use GET /logs/recent and GET /logs/metrics for router observability.
+Treat batch `ok:false` rows as partial failures and continue processing remaining targets.
+Never execute suggested remediation commands; report them as recommendations only.
+```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npm run dev
 - `POST /analyze/logs`
 - `GET /logs/recent`
 - `GET /logs/metrics`
+- `GET /version`
 - `GET /healthz`
 
 ## Envelope Contract
@@ -96,6 +97,8 @@ Security controls:
 - `DEBATE_MODEL_ALLOWLIST` (comma-separated model IDs allowed for `/v1/debate`)
 - `DEBATE_MAX_CONCURRENT` (default `1`; max active `/v1/debate` requests)
 - `LOG_BUFFER_MAX_ENTRIES` (default `2000`; in-memory API log buffer size for `/logs/*`)
+- `BUILD_GIT_SHA` (optional; exposed by `GET /version`)
+- `BUILD_TIME` (optional ISO timestamp; exposed by `GET /version`)
 
 ## Quick Tests
 Streaming CHAT:
@@ -176,6 +179,11 @@ curl -sS "http://127.0.0.1:3000/logs/recent?limit=100"
 API metrics (last 1 hour):
 ```bash
 curl -sS "http://127.0.0.1:3000/logs/metrics?window=1h"
+```
+
+Runtime version:
+```bash
+curl -sS "http://127.0.0.1:3000/version"
 ```
 
 ## OpenClaw Provider Setup

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,13 +9,19 @@ import { ollamaBaseURL, runWorkerText, runWorkerTextStream } from './ollama.js';
 import { getLogMetrics, getRecentLogs, log } from './log.js';
 import { sanitizeLLMOutput } from './sanitize.js';
 import { registerLogExplainerRoutes } from './logExplainer/route.js';
+import { getVersionInfo } from './version.js';
 
 const app = express();
 const port = Number(process.env.PORT ?? 3000);
 const maxActiveDebates = Number(process.env.DEBATE_MAX_CONCURRENT ?? 1);
 let activeDebates = 0;
+const versionInfo = getVersionInfo();
 
 app.use(express.json({ limit: '1mb' }));
+app.use((_req, res, next) => {
+  res.setHeader('x-blackice-version', versionInfo.version);
+  next();
+});
 registerLogExplainerRoutes(app);
 
 function nowSeconds(): number {
@@ -379,6 +385,13 @@ app.get('/v1/debate/schema', (_req: Request, res: Response) => {
 
 app.get('/healthz', (_req: Request, res: Response) => {
   res.status(200).json({ ok: true });
+});
+
+app.get('/version', (_req: Request, res: Response) => {
+  res.status(200).json({
+    ok: true,
+    ...versionInfo
+  });
 });
 
 app.get('/logs/recent', (req: Request, res: Response) => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+
+type VersionInfo = {
+  name: string;
+  version: string;
+  gitSha: string | null;
+  buildTime: string | null;
+};
+
+let cached: VersionInfo | null = null;
+
+function readPackageJson(): { name: string; version: string } {
+  const raw = readFileSync(new URL('../package.json', import.meta.url), 'utf8');
+  const parsed = JSON.parse(raw) as { name?: unknown; version?: unknown };
+  return {
+    name: typeof parsed.name === 'string' ? parsed.name : 'blackice-policy-router',
+    version: typeof parsed.version === 'string' ? parsed.version : '0.0.0'
+  };
+}
+
+export function getVersionInfo(): VersionInfo {
+  if (cached) {
+    return cached;
+  }
+
+  const pkg = readPackageJson();
+  cached = {
+    name: pkg.name,
+    version: pkg.version,
+    gitSha: process.env.BUILD_GIT_SHA ?? null,
+    buildTime: process.env.BUILD_TIME ?? null
+  };
+  return cached;
+}


### PR DESCRIPTION
## Summary
Add explicit runtime/app versioning so clients (including OpenClaw) can verify what BlackIce build is currently deployed.

## Changes
- Add `src/version.ts` to load `name` + `version` from `package.json` and optional build metadata from env:
  - `BUILD_GIT_SHA`
  - `BUILD_TIME`
- Update `src/server.ts`:
  - `GET /version` endpoint returning runtime version metadata
  - global response header `x-blackice-version` on all responses
- Update docs:
  - `README.md` with endpoint/env/curl examples
  - `OPENCLAW_KT_LOG_OBSERVABILITY.md` with version call for tool discovery

## Why
- Enables deterministic runtime verification after deploys
- Gives OpenClaw and operators a simple API for compatibility checks
- Improves observability without adding auth, DB, or non-read-only behavior

## Validation
- `npm run build` passes

## Example
```bash
curl -sS http://192.168.1.130:3000/version
curl -i -sS http://192.168.1.130:3000/healthz | grep -i x-blackice-version
```
