### PR TITLE
ci(release): auto-version on PR merge to main

### DIFF
--- a/.github/workflows/auto-version-on-merge.yml
+++ b/.github/workflows/auto-version-on-merge.yml
@@ -1,0 +1,35 @@
+name: Auto Version On Merge
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    if: ${{ github.actor != 'github-actions[bot]' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump patch version and create tag
+        run: npm version patch -m "chore(release): %s [skip ci]"
+
+      - name: Push version commit and tag
+        run: git push origin main --follow-tags

--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ curl -sS "http://127.0.0.1:3000/version"
 - Phase 2 multi-LXC handoff: `PHASE2_LXC_LOG_EXPOSURE_HANDOFF.md`
 
 ## Versioning And Tags
+- Automatic patch release on PR merge to `main`:
+```bash
+# Implemented via .github/workflows/auto-version-on-merge.yml
+# Behavior: bump patch, commit, create v* tag, push with --follow-tags
+```
 - Semver release tags (creates commit + tag):
 ```bash
 npm run version:patch
@@ -210,3 +215,6 @@ git push origin main --follow-tags
 npm run tag:change
 git push origin main --tags
 ```
+
+Repository setting needed:
+- `Actions` must have permission to write repository contents (for push + tags).


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that automatically creates a new patch version after PR merges land on `main`.

## What it does
- Triggers on pushes to `main` (including merge commits)
- Runs `npm version patch`
- Creates a release commit (`chore(release): vX.Y.Z [skip ci]`)
- Creates and pushes the `vX.Y.Z` tag

## Safety / Loop prevention
- Job is skipped when actor is `github-actions[bot]`
- Job is skipped when commit message already starts with `chore(release):`
- Prevents recursive release runs from the bot's own version commit

## Files changed
- `.github/workflows/auto-version-on-merge.yml`
- `README.md` (versioning section)

## Repo setting required
Ensure GitHub Actions has write permission for repository contents so it can push commit + tags.
