### PR TITLE
ci(release): auto-version on PR merge to main

### DIFF
--- a/.github/workflows/auto-version-on-merge.yml
+++ b/.github/workflows/auto-version-on-merge.yml
@@ -29,7 +29,16 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Bump patch version and create tag
-        run: npm version patch -m "chore(release): %s [skip ci]"
+        id: bump
+        run: |
+          npm version patch -m "chore(release): %s [skip ci]"
+          echo "tag=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Push version commit and tag
         run: git push origin main --follow-tags
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.bump.outputs.tag }}
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ curl -sS "http://127.0.0.1:3000/version"
 ```bash
 # Implemented via .github/workflows/auto-version-on-merge.yml
 # Behavior: bump patch, commit, create v* tag, push with --follow-tags
+# Also creates a GitHub Release with generated notes
 ```
 - Semver release tags (creates commit + tag):
 ```bash


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that automatically creates a new patch version after PR merges land on `main`.

## What it does
- Triggers on pushes to `main` (including merge commits)
- Runs `npm version patch`
- Creates a release commit (`chore(release): vX.Y.Z [skip ci]`)
- Creates and pushes the `vX.Y.Z` tag

## Safety / Loop prevention
- Job is skipped when actor is `github-actions[bot]`
- Job is skipped when commit message already starts with `chore(release):`
- Prevents recursive release runs from the bot's own version commit

## Files changed
- `.github/workflows/auto-version-on-merge.yml`
- `README.md` (versioning section)

## Repo setting required
Ensure GitHub Actions has write permission for repository contents so it can push commit + tags.
