### PR TITLE
feat(observability): Propagate x-request-id OpenClaw → BlackIce → Ollama

### DIFF
--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -40,16 +40,22 @@ export type GenerateParams = {
   temperature?: number;
   maxTokens?: number;
   explicitJsonAllowed?: boolean;
+  requestId?: string;
 };
 
 export async function runWorkerText(params: GenerateParams): Promise<{ text: string }> {
   const prompt = buildWorkerContractPrompt(params.input, params.explicitJsonAllowed);
+  const headers: Record<string, string> = {};
+  if (params.requestId) {
+    headers['X-Request-ID'] = params.requestId;
+  }
   const model = resolveModel(params.modelId) as Parameters<typeof generateText>[0]['model'];
   const result = await generateText({
     model,
     prompt,
     temperature: params.temperature,
-    maxOutputTokens: params.maxTokens
+    maxOutputTokens: params.maxTokens,
+    headers: Object.keys(headers).length > 0 ? headers : undefined
   });
 
   const sanitized = sanitizeLLMOutput(result.text);
@@ -62,13 +68,18 @@ export async function runWorkerText(params: GenerateParams): Promise<{ text: str
 
 export function runWorkerTextStream(params: GenerateParams) {
   const prompt = buildWorkerContractPrompt(params.input, params.explicitJsonAllowed);
+  const headers: Record<string, string> = {};
+  if (params.requestId) {
+    headers['X-Request-ID'] = params.requestId;
+  }
   const model = resolveModel(params.modelId) as Parameters<typeof streamText>[0]['model'];
 
   return streamText({
     model,
     prompt,
     temperature: params.temperature,
-    maxOutputTokens: params.maxTokens
+    maxOutputTokens: params.maxTokens,
+    headers: Object.keys(headers).length > 0 ? headers : undefined
   });
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,12 +64,13 @@ function buildMessageResponse(model: string, text: string) {
   };
 }
 
-async function handleChatStreaming(res: Response, modelId: string, input: string, temperature?: number, maxTokens?: number): Promise<void> {
+async function handleChatStreaming(res: Response, modelId: string, input: string, temperature?: number, maxTokens?: number, requestId?: string): Promise<void> {
   const streamResult = runWorkerTextStream({
     modelId,
     input,
     temperature,
-    maxTokens
+    maxTokens,
+    requestId
   });
 
   const id = openAICompletionId();
@@ -235,7 +236,7 @@ app.post('/v1/chat/completions', async (req: Request, res: Response) => {
     const route = chooseChatModel(body.messages);
 
     if (body.stream) {
-      await handleChatStreaming(res, route.model, envelope.raw, body.temperature, body.max_tokens);
+      await handleChatStreaming(res, route.model, envelope.raw, body.temperature, body.max_tokens, requestId);
 
       log.info('request_complete', {
         request_id: requestId,
@@ -251,7 +252,8 @@ app.post('/v1/chat/completions', async (req: Request, res: Response) => {
       modelId: route.model,
       input: envelope.raw,
       temperature: body.temperature,
-      maxTokens: body.max_tokens
+      maxTokens: body.max_tokens,
+      requestId
     });
 
     const sanitized = sanitizeLLMOutput(result.text);


### PR DESCRIPTION
This PR addresses issue #12 by implementing the propagation of  from incoming OpenClaw requests through BlackIce to Ollama. This significantly improves end-to-end observability for LLM interactions.\n\n**Changes include:**\n- Updated  type in  to accept .
- Modified  and  in  to pass  as an  header to Ollama.
- Updated  and  calls in  to forward the  from the incoming request.\n\nCloses #12