### PR TITLE
fix: Loki batch error message serialization

### DIFF
--- a/src/logExplainer/route.ts
+++ b/src/logExplainer/route.ts
@@ -331,7 +331,7 @@ export function registerLogExplainerRoutes(app: Express): void {
           result = {
             target: fallbackTarget,
             ok: false,
-            error: errMessage(httpError),
+            error: httpError.message,
             status: httpError.status
           };
         }


### PR DESCRIPTION
## Summary
- fix Loki query-mode batch error mapping to return a human-readable message string
- replace object stringification (`[object Object]`) with `httpError.message`

## Why
When guardrails rejected a Loki request (for example missing host/unit scope), the response surfaced `error: "[object Object]"` instead of the actual error text.

## Validation
- npm run build
- manually verified response now includes text error message in `results[0].error`