### PR TITLE
feat(log-explainer): add Loki sinceSeconds and regex filters

### DIFF
--- a/LOG_EXPLAINER.md
+++ b/LOG_EXPLAINER.md
@@ -65,8 +65,8 @@ curl -sS http://127.0.0.1:3000/analyze/logs/batch \
       "unit": "blackice-router.service"
     },
     "contains": "request_id=...",
-    "start": "2026-03-01T04:00:00Z",
-    "end": "2026-03-01T04:15:00Z",
+    "regex": "status=(5..|4..)",
+    "sinceSeconds": 900,
     "limit": 2000,
     "evidenceLines": 10
   }'

--- a/OPENCLAW_LOG_EXPLAINER.md
+++ b/OPENCLAW_LOG_EXPLAINER.md
@@ -68,8 +68,8 @@ Example Loki batch request (structured filters):
     "job": "journald"
   },
   "contains": "request_id=...",
-  "start": "2026-03-01T04:00:00Z",
-  "end": "2026-03-01T04:15:00Z",
+  "regex": "status=(5..|4..)",
+  "sinceSeconds": 900,
   "limit": 2000,
   "evidenceLines": 10
 }
@@ -105,7 +105,9 @@ Example batch response shape:
 - For `source: "loki"`, provide `filters`; raw LogQL `query` and selector strings are rejected.
 - For `source: "loki"`, allowlist rules are loaded from `LOKI_RULES_FILE` YAML.
 - For `source: "loki"`, default time window is last 15 minutes if `start`/`end` are omitted.
+- For `source: "loki"`, use `sinceSeconds` for relative windows; do not combine with `start`/`end`.
 - For `source: "loki"`, max time window is controlled by `LOKI_MAX_WINDOW_MINUTES` (default 60).
+- For `source: "loki"`, optional `regex` adds a LogQL regex pipeline filter (`|~`).
 - Set `evidenceLines` (max `50`) to include bounded, redacted raw evidence lines in successful batch results.
 - The service enforces read-only safety; unsafe command-like output is redacted before response.
 - This endpoint is separate from `/v1/chat/completions`; call it as a direct HTTP integration.

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ curl -sS http://127.0.0.1:3000/analyze/logs/batch \
     "source": "loki",
     "filters": {"job":"journald","host":"owonto","unit":"blackice-router.service"},
     "contains": "request_id=",
+    "regex": "status=(5..|4..)",
+    "sinceSeconds": 900,
     "limit": 500,
     "evidenceLines": 10
   }'

--- a/src/logExplainer/logCollector.ts
+++ b/src/logExplainer/logCollector.ts
@@ -441,7 +441,8 @@ export function buildEffectiveLokiQuery(input: AnalyzeLogsBatchLokiRequest): str
   const entries = Object.entries(input.filters).sort(([a], [b]) => a.localeCompare(b));
   const selector = entries.map(([key, value]) => `${key}="${escapeLogQLLabelValue(value)}"`).join(',');
   const contains = input.contains ? ` |= "${escapeLogQLStringLiteral(input.contains)}"` : '';
-  return `{${selector}}${contains}`;
+  const regex = input.regex ? ` |~ "${escapeLogQLStringLiteral(input.regex)}"` : '';
+  return `{${selector}}${contains}${regex}`;
 }
 
 function enforceScopeGuard(input: AnalyzeLogsBatchLokiRequest, effectiveQuery: string): void {
@@ -461,12 +462,24 @@ function enforceScopeGuard(input: AnalyzeLogsBatchLokiRequest, effectiveQuery: s
 export function resolveLokiTimeRange(input: {
   start?: string;
   end?: string;
+  sinceSeconds?: number;
 }): { startNs: string; endNs: string; hours: number } {
   const now = new Date();
-  const fallbackEnd = now;
-  const fallbackStart = new Date(now.getTime() - Math.max(1, LOKI_DEFAULT_WINDOW_MINUTES) * 60 * 1000);
-  const startDate = input.start ? new Date(input.start) : fallbackStart;
-  const endDate = input.end ? new Date(input.end) : fallbackEnd;
+  let startDate: Date;
+  let endDate: Date;
+
+  if (typeof input.sinceSeconds === 'number') {
+    if (!Number.isInteger(input.sinceSeconds) || input.sinceSeconds <= 0) {
+      throw buildError(400, 'sinceSeconds must be a positive integer');
+    }
+    endDate = now;
+    startDate = new Date(now.getTime() - input.sinceSeconds * 1_000);
+  } else {
+    const fallbackEnd = now;
+    const fallbackStart = new Date(now.getTime() - Math.max(1, LOKI_DEFAULT_WINDOW_MINUTES) * 60 * 1000);
+    startDate = input.start ? new Date(input.start) : fallbackStart;
+    endDate = input.end ? new Date(input.end) : fallbackEnd;
+  }
 
   if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
     throw buildError(400, 'start/end must be valid ISO-8601 timestamps');
@@ -728,7 +741,8 @@ export async function collectLokiBatchLogs(input: AnalyzeLogsBatchLokiRequest): 
   ensureAllowlistedSelectorFromQuery(query);
   const { startNs, endNs, hours } = resolveLokiTimeRange({
     start: input.start,
-    end: input.end
+    end: input.end,
+    sinceSeconds: input.sinceSeconds
   });
   const limit = clampLokiLimit(input.limit ?? 2_000);
   const logs = await queryLokiRange({

--- a/src/logExplainer/route.ts
+++ b/src/logExplainer/route.ts
@@ -218,8 +218,10 @@ export function registerLogExplainerRoutes(app: Express): void {
             targets: 'string[] (optional; journald units)',
             filters: 'record<string,string> (required when source=loki; selector labels)',
             contains: 'string (optional; source=loki line filter)',
+            regex: 'string (optional; source=loki regex line filter)',
             start: 'ISO-8601 datetime (optional; source=loki)',
             end: 'ISO-8601 datetime (optional; source=loki)',
+            sinceSeconds: 'number (optional; source=loki relative time window)',
             limit: 'number (optional; source=loki)',
             allowUnscoped: 'boolean (optional; source=loki)',
             hours: 'number (optional)',
@@ -278,8 +280,10 @@ export function registerLogExplainerRoutes(app: Express): void {
           source: 'loki' as const,
           filters: body.filters,
           contains: body.contains,
+          regex: body.regex,
           start: body.start,
           end: body.end,
+          sinceSeconds: body.sinceSeconds,
           limit: body.limit,
           allowUnscoped: body.allowUnscoped
         };

--- a/src/logExplainer/schema.ts
+++ b/src/logExplainer/schema.ts
@@ -42,8 +42,10 @@ export const AnalyzeLogsBatchRequestSchema = z
     query: z.string().min(1).max(4_000).optional(),
     filters: LokiFiltersSchema.optional(),
     contains: z.string().min(1).max(500).optional(),
+    regex: z.string().min(1).max(500).optional(),
     start: z.string().datetime({ offset: true }).optional(),
     end: z.string().datetime({ offset: true }).optional(),
+    sinceSeconds: z.number().int().positive().max(ANALYZE_MAX_HOURS * 60 * 60).optional(),
     limit: z.number().int().positive().max(LOKI_MAX_LIMIT_REQUEST).optional().default(2_000),
     allowUnscoped: z.boolean().optional().default(false),
     hours: z.number().positive().max(ANALYZE_MAX_HOURS).optional().default(6),
@@ -93,6 +95,14 @@ export const AnalyzeLogsBatchRequestSchema = z
         code: z.ZodIssueCode.custom,
         path: ['filters'],
         message: 'filters are required for source=loki'
+      });
+    }
+
+    if (value.sinceSeconds !== undefined && (value.start !== undefined || value.end !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['sinceSeconds'],
+        message: 'provide either sinceSeconds or start/end for source=loki, not both'
       });
     }
   })
@@ -210,8 +220,10 @@ export type AnalyzeLogsBatchLokiRequest = {
   query?: string;
   filters?: Record<string, string>;
   contains?: string;
+  regex?: string;
   start?: string;
   end?: string;
+  sinceSeconds?: number;
   limit?: number;
   allowUnscoped?: boolean;
 };


### PR DESCRIPTION
## Summary
- add Loki batch request params `sinceSeconds` and optional `regex`
- apply `contains` and optional `regex` as LogQL pipeline filters (`|=` and `|~`) in filters-based Loki queries
- support `sinceSeconds` relative window in Loki time-range resolution
- preserve strict Loki guardrails: no raw query strings/selectors accepted at route level

## Validation
- `pnpm install`
- `pnpm build`

Closes #42
