### PR TITLE
feat: add Loki discovery metadata to /analyze/logs/targets

### DIFF
--- a/src/logExplainer/logCollector.ts
+++ b/src/logExplainer/logCollector.ts
@@ -41,6 +41,16 @@ type LokiRulesConfig = {
   unitsRegex: RegExp | null;
 };
 
+export type LokiDiscoveryMetadata = {
+  job?: string;
+  allowedLabels: string[];
+  hosts: string[];
+  units: string[];
+  hasHostsRegex: boolean;
+  hasUnitsRegex: boolean;
+  requireScopeLabels: boolean;
+};
+
 let cachedLokiRules: LokiRulesConfig | null = null;
 
 function buildError(status: number, message: string): Error & { status: number } {
@@ -366,8 +376,33 @@ export function ensureLokiRulesConfigured(): void {
 
 export function getLokiSyntheticTargets(): string[] {
   // Loki selector strings are intentionally not accepted by /analyze/logs/batch.
-  // Keep targets empty until structured discovery metadata is added.
   return [];
+}
+
+export function getLokiDiscoveryMetadata(): LokiDiscoveryMetadata {
+  ensureLokiRulesConfigured();
+
+  if (!isLokiEnabled()) {
+    return {
+      allowedLabels: [],
+      hosts: [],
+      units: [],
+      hasHostsRegex: false,
+      hasUnitsRegex: false,
+      requireScopeLabels: false
+    };
+  }
+
+  const rules = loadLokiRulesConfig();
+  return {
+    job: rules.job,
+    allowedLabels: [...rules.allowedLabels].sort(),
+    hosts: [...rules.hosts].sort(),
+    units: [...rules.units].sort(),
+    hasHostsRegex: rules.hostsRegex !== null,
+    hasUnitsRegex: rules.unitsRegex !== null,
+    requireScopeLabels: LOKI_REQUIRE_SCOPE_LABELS
+  };
 }
 
 export function validateAllowedLokiSelector(selector: string): string {

--- a/src/logExplainer/route.ts
+++ b/src/logExplainer/route.ts
@@ -18,6 +18,7 @@ import {
   collectLogs,
   collectLokiBatchLogs,
   ensureLokiRulesConfigured,
+  getLokiDiscoveryMetadata,
   getLokiSyntheticTargets
 } from './logCollector.js';
 import { analyzeLogsWithOllama } from './ollamaClient.js';
@@ -202,7 +203,8 @@ export function registerLogExplainerRoutes(app: Express): void {
     try {
       ensureLokiRulesConfigured();
       const targets = [...getLokiSyntheticTargets()];
-      const body = AnalyzeLogsTargetsResponseSchema.parse({ targets });
+      const discovery = getLokiDiscoveryMetadata();
+      const body = AnalyzeLogsTargetsResponseSchema.parse({ targets, discovery });
       res.status(200).json(body);
     } catch (error: unknown) {
       const httpError = toHttpError(error);

--- a/src/logExplainer/schema.ts
+++ b/src/logExplainer/schema.ts
@@ -110,9 +110,22 @@ export const AnalyzeLogsBatchRequestSchema = z
   })
   .strict();
 
+const LokiDiscoverySchema = z
+  .object({
+    job: z.string().optional(),
+    allowedLabels: z.array(z.string()),
+    hosts: z.array(z.string()),
+    units: z.array(z.string()),
+    hasHostsRegex: z.boolean(),
+    hasUnitsRegex: z.boolean(),
+    requireScopeLabels: z.boolean()
+  })
+  .strict();
+
 export const AnalyzeLogsTargetsResponseSchema = z
   .object({
-    targets: z.array(z.string())
+    targets: z.array(z.string()),
+    discovery: LokiDiscoverySchema.optional()
   })
   .strict();
 
@@ -244,6 +257,20 @@ export const LogExplainerJsonSchemas = {
       targets: {
         type: 'array',
         items: { type: 'string' }
+      },
+      discovery: {
+        type: 'object',
+        required: ['allowedLabels', 'hosts', 'units', 'hasHostsRegex', 'hasUnitsRegex', 'requireScopeLabels'],
+        properties: {
+          job: { type: 'string' },
+          allowedLabels: { type: 'array', items: { type: 'string' } },
+          hosts: { type: 'array', items: { type: 'string' } },
+          units: { type: 'array', items: { type: 'string' } },
+          hasHostsRegex: { type: 'boolean' },
+          hasUnitsRegex: { type: 'boolean' },
+          requireScopeLabels: { type: 'boolean' }
+        },
+        additionalProperties: false
       }
     },
     additionalProperties: false


### PR DESCRIPTION
## Summary\n- add a structured `discovery` object to `GET /analyze/logs/targets`\n- include Loki rules metadata: `job`, `allowedLabels`, `hosts`, `units`, regex capability flags, and `requireScopeLabels`\n- keep existing `targets` field unchanged for backward compatibility\n- update exported JSON schema metadata to document the new response contract\n\n## Manual verification\n1. Run `npm run build`\n2. Call `GET /analyze/logs/targets` with Loki enabled and verify response includes:\n   - `targets`\n   - `discovery.allowedLabels`, `discovery.hosts`, `discovery.units`\n   - `discovery.hasHostsRegex`, `discovery.hasUnitsRegex`, `discovery.requireScopeLabels`\n3. Confirm existing clients that only read `targets` continue to work unchanged\n\nCloses #48