### PR TITLE
Fix: [easy] Ignore generated local directories in .gitignore (Closes #74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ npm-shrinkwrap.json
 
 # coverage
 coverage/
+output/
+tmp/
+.codex-worktrees/


### PR DESCRIPTION
Closes #74

## Summary
- minimal scoped fix for issue #74
- telemetry collection enabled for autonomous worker runs

## Risk
- low