### PR TITLE
refactor: centralize env parsing with Zod schema

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  PORT: z.coerce.number().int().default(3000),
+  DEBATE_MAX_CONCURRENT: z.coerce.number().int().min(1).max(100).default(1),
+
+  LOG_LEVEL: z.enum(['debug', 'info']).default('info'),
+  LOG_BUFFER_MAX_ENTRIES: z.coerce.number().int().min(100).max(10_000).default(2000),
+})
+
+export type Env = z.infer<typeof envSchema>
+
+const envParseResult = envSchema.safeParse(process.env)
+
+if (!envParseResult.success) {
+  process.stderr.write(`Invalid environment variables:\n${z.prettifyError(envParseResult.error)}\n`)
+  process.exit(1)
+}
+
+export const env: Env = envParseResult.data

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -11,21 +11,21 @@ afterEach(() => {
 
 describe('log.ts', () => {
   it('stores logs in buffer and trims to configured max size', async () => {
-    vi.stubEnv('LOG_BUFFER_MAX_ENTRIES', '2')
+    vi.stubEnv('LOG_BUFFER_MAX_ENTRIES', '100')
     const { log, getRecentLogs } = await import('./log.js')
 
-    log.info('first', { a: 1 })
-    log.info('second', { a: 2 })
-    log.info('third', { a: 3 })
+    for (let i = 0; i < 101; i++) {
+      log.info(`msg_${i}`, { i })
+    }
 
-    const recent = getRecentLogs(10)
-    expect(recent).toHaveLength(2)
-    expect(recent[0].msg).toBe('second')
-    expect(recent[1].msg).toBe('third')
+    const recent = getRecentLogs(200)
+    expect(recent).toHaveLength(100)
+    expect(recent[0].msg).toBe('msg_1')
+    expect(recent[recent.length - 1].msg).toBe('msg_100')
   })
 
   it('includes error entries in metrics and recent logs', async () => {
-    vi.stubEnv('LOG_BUFFER_MAX_ENTRIES', '10')
+    vi.stubEnv('LOG_BUFFER_MAX_ENTRIES', '100')
     const { log, getRecentLogs, getLogMetrics } = await import('./log.js')
 
     log.info('ok_event')

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,3 +1,5 @@
+import { env } from './config/env.js'
+
 type LogLevel = 'debug' | 'info'
 type LogLevelWithError = LogLevel | 'error'
 
@@ -8,24 +10,8 @@ type LogEntry = {
   fields: Record<string, unknown>
 }
 
-const level: LogLevel = process.env.LOG_LEVEL === 'debug' ? 'debug' : 'info'
-
-function parseMaxLogBufferEntries(raw: string | undefined): number {
-  const defaultValue = 2000
-  if (!raw) {
-    return defaultValue
-  }
-
-  const parsed = Number(raw)
-  if (!Number.isFinite(parsed)) {
-    // Fallback to default when env is not a finite number.
-    return defaultValue
-  }
-
-  return Math.max(1, Math.min(10_000, Math.floor(parsed)))
-}
-
-const maxLogBufferEntries = parseMaxLogBufferEntries(process.env.LOG_BUFFER_MAX_ENTRIES)
+const level: LogLevel = env.LOG_LEVEL
+const maxLogBufferEntries = env.LOG_BUFFER_MAX_ENTRIES
 const logBuffer: LogEntry[] = []
 
 function shouldLog(msgLevel: LogLevel): boolean {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,33 +1,13 @@
+import { env } from './config/env.js'
 import { ollamaBaseURL } from './ollama.js'
 import { log } from './log.js'
 import { createApp } from './app.js'
 
-const port = Number(process.env.PORT ?? 3000)
-
-function parseDebateMaxConcurrent(raw: string | undefined): {
-  value: number
-  usedFallback: boolean
-} {
-  const parsed = Number(raw ?? 1)
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return { value: 1, usedFallback: true }
-  }
-
-  return { value: Math.floor(parsed), usedFallback: false }
-}
-
-const debateMaxConcurrent = parseDebateMaxConcurrent(process.env.DEBATE_MAX_CONCURRENT)
-const maxActiveDebates = debateMaxConcurrent.value
+const port = env.PORT
+const maxActiveDebates = env.DEBATE_MAX_CONCURRENT
 
 const app = createApp(maxActiveDebates)
 
 app.listen(port, () => {
-  if (debateMaxConcurrent.usedFallback) {
-    log.info('debate_max_concurrent_fallback', {
-      configured: process.env.DEBATE_MAX_CONCURRENT ?? null,
-      applied: maxActiveDebates,
-    })
-  }
-
   log.info('server_started', { port, ollama_base_url: ollamaBaseURL })
 })


### PR DESCRIPTION
## Changes
- Add src/config/env.ts with Zod-based envSchema
- Refactor server.ts and log.ts to use centralized env object
- Update log.test.ts to respect new validation bounds

## Example Output
Running with an invalid PORT value:
<img width="666" height="208" alt="image" src="https://github.com/user-attachments/assets/19b3b73d-24ea-4d42-bf4a-feb34c500cd8" />

## Issue
Closes #81 
