### PR TITLE
Fix #77: [easy] Document /v1/debate/schema in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ pnpm run dev
 ## Endpoints
 - `POST /v1/chat/completions`
 - `POST /v1/debate`
+- `GET /v1/debate/schema`
 - `POST /analyze/logs`
 - `POST /v1/policy/dry-run`
 - `GET /logs/recent` *(requires `OPS_ENABLED=1`)*
@@ -254,6 +255,11 @@ curl -sS -i http://127.0.0.1:3000/v1/debate \
     "turnsPerRound": 4,
     "includeModeratorSummary": true
   }'
+```
+
+Debate schema route:
+```bash
+curl -sS http://127.0.0.1:3000/v1/debate/schema
 ```
 
 Log Explainer route:


### PR DESCRIPTION
## Summary
- add `GET /v1/debate/schema` to the README endpoint list
- add a short curl example for the schema endpoint in the quick test section

## Reasoning
The route already exists in code, but it was missing from the README. Documenting it makes API discovery easier and keeps the README aligned with the current route contract.

## Limitations
This PR only updates documentation. It does not change runtime behavior.

Generated by OpenClaw automation.
