### PR TITLE
fix: validate /analyze/logs/metadata response

### DIFF
--- a/src/logExplainer/route.ts
+++ b/src/logExplainer/route.ts
@@ -5,6 +5,7 @@ import {
   BATCH_EVIDENCE_LINES_MAX,
   AnalyzeLogsBatchRequestSchema,
   AnalyzeLogsBatchResponseSchema,
+  AnalyzeLogsMetadataResponseSchema,
   AnalyzeLogsRequestSchema,
   AnalyzeLogsResponseSchema,
   AnalyzeLogsTargetsResponseSchema,
@@ -348,8 +349,7 @@ export function registerLogExplainerRoutes(app: Express): void {
 
   app.get('/analyze/logs/metadata', (_req: Request, res: Response) => {
     const status = buildLogExplainerStatus()
-
-    res.status(200).json({
+    const body = AnalyzeLogsMetadataResponseSchema.parse({
       name: 'blackice-log-explainer',
       version: 1,
       description: 'Read-only log analysis service for OpenClaw integration',
@@ -357,6 +357,8 @@ export function registerLogExplainerRoutes(app: Express): void {
       status,
       schemas: LogExplainerJsonSchemas,
     })
+
+    res.status(200).json(body)
   })
 
   app.post('/analyze/logs/batch', async (req: Request, res: Response) => {

--- a/src/logExplainer/schema.ts
+++ b/src/logExplainer/schema.ts
@@ -235,6 +235,30 @@ export const AnalyzeLogsStatusResponseSchema = z
   })
   .strict()
 
+const LogExplainerMetadataEndpointSchema = z
+  .object({
+    method: z.enum(['GET', 'POST']),
+    path: z.string(),
+    requestSchema: z.record(z.string(), z.string()).optional(),
+    responseSchema: z.unknown().optional(),
+  })
+  .strict()
+
+export const AnalyzeLogsMetadataResponseSchema = z
+  .object({
+    name: z.literal('blackice-log-explainer'),
+    version: z.literal(1),
+    description: z.literal('Read-only log analysis service for OpenClaw integration'),
+    endpoints: z.record(z.string(), LogExplainerMetadataEndpointSchema),
+    status: AnalyzeLogsStatusResponseSchema,
+    schemas: z.object({
+      analyzeLogsTargetsResponse: z.unknown(),
+      analyzeLogsResponse: z.unknown(),
+      analyzeLogsBatchResponse: z.unknown(),
+    }),
+  })
+  .strict()
+
 export type AnalyzeLogsRequest = z.infer<typeof AnalyzeLogsRequestSchema>
 export type AnalyzeLogsBatchRequest = z.infer<typeof AnalyzeLogsBatchRequestSchema>
 export type AnalyzeLogsBatchLokiRequest = {
@@ -255,6 +279,7 @@ export type AnalyzeLogsBatchResultOk = z.infer<typeof AnalyzeLogsBatchResultOkSc
 export type AnalyzeLogsBatchResultError = z.infer<typeof AnalyzeLogsBatchResultErrorSchema>
 export type AnalyzeLogsBatchResponse = z.infer<typeof AnalyzeLogsBatchResponseSchema>
 export type AnalyzeLogsStatusResponse = z.infer<typeof AnalyzeLogsStatusResponseSchema>
+export type AnalyzeLogsMetadataResponse = z.infer<typeof AnalyzeLogsMetadataResponseSchema>
 
 export const LogExplainerJsonSchemas = {
   analyzeLogsTargetsResponse: {

--- a/src/routes.integration.test.ts
+++ b/src/routes.integration.test.ts
@@ -88,6 +88,7 @@ describe('integration routes', () => {
 
   it('GET /analyze/logs/metadata stays aligned with status endpoint list', async () => {
     const { createApp } = await import('./app.js')
+    const { AnalyzeLogsMetadataResponseSchema } = await import('./logExplainer/schema.js')
     const app = createApp(1)
 
     const [statusRes, metadataRes] = await Promise.all([
@@ -97,6 +98,7 @@ describe('integration routes', () => {
 
     expect(statusRes.status).toBe(200)
     expect(metadataRes.status).toBe(200)
+    expect(() => AnalyzeLogsMetadataResponseSchema.parse(metadataRes.body)).not.toThrow()
 
     const metadataEndpoints = Object.values(metadataRes.body.endpoints) as Array<{
       method: string


### PR DESCRIPTION
## Summary
- add a dedicated Zod schema and exported TypeScript type for the metadata response
- validate the /analyze/logs/metadata payload before returning it
- extend the integration test to parse the metadata response through the new schema

## Validation
- pnpm test:integration
- pnpm build

Closes #107
