### PR TITLE
docs: add first-time contributor map and local dev quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,36 @@ curl -sS "http://127.0.0.1:3000/version"
 - OpenClaw Log Explainer integration: `OPENCLAW_LOG_EXPLAINER.md`
 - Phase 2 multi-LXC handoff: `PHASE2_LXC_LOG_EXPOSURE_HANDOFF.md`
 
+## First-time Contributors
+
+If you are new to the repo, read in this order:
+1. `README.md` sections `Install`, `Run`, and `Source Layout`
+2. `src/app.ts` to see how the server is assembled
+3. `src/routes/chatCompletions.ts` and `src/chat/routeResolution.ts` for the main request path
+
+Start here for smaller changes:
+- `src/app.ts`
+- `src/routes/chatCompletions.ts`
+- `src/chat/routeResolution.ts`
+- `src/config/env.ts`
+
+Higher-complexity areas:
+- `src/logExplainer/route.ts`
+- `src/logExplainer/logCollector.ts`
+
+Smallest useful local feedback loop:
+```bash
+pnpm install
+pnpm test
+BLACKICE_CONFIG_FILE=./config/blackice.local.yaml pnpm run dev
+```
+
+More targeted checks when needed:
+- `pnpm run test:unit`
+- `pnpm run test:integration`
+
+For local development, use `./config/blackice.local.yaml`.
+
 ## Versioning And Tags
 - Automatic patch release on PR merge to `main`:
 ```bash


### PR DESCRIPTION
## Summary
- add a short `First-time Contributors` section to `README.md`
- point new contributors to a lightweight reading order and smaller entry points
- call out `logExplainer` files as higher complexity areas
- document the minimum install, test, and local run commands
- specify `./config/blackice.local.yaml` for local development

## Acceptance criteria
- recommended reading order for first-time contributors: covered
- easier entry points vs higher complexity areas: covered
- `logExplainer` explicitly called out: covered
- smallest useful local feedback loop: covered with `pnpm install`, `pnpm test`, and `BLACKICE_CONFIG_FILE=./config/blackice.local.yaml pnpm run dev`
- local development config file: covered
- guidance stays short and avoids duplicating the rest of the README: covered

## Validation
- reviewed final README diff against issue requirements
- confirmed branch was created from the latest `main`
- confirmed only `README.md` was modified
- ran `git diff --check`
- ran `pnpm run test:unit`

Closes #125
