### PR TITLE
docs: add first-time contributor guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,34 @@ pnpm run dev
 - Canonical runtime source lives in `src/` (TypeScript).
 - Legacy root JavaScript modules were removed; runtime code should live under `src/` only.
 
+## First-time contributors
+Start with the smallest local loop:
+
+```bash
+pnpm install
+BLACKICE_CONFIG_FILE=./config/blackice.local.yaml pnpm test
+BLACKICE_CONFIG_FILE=./config/blackice.local.yaml pnpm run dev
+```
+
+Recommended reading order:
+1. `README.md`
+2. `src/app.ts`
+3. `src/routes/chatCompletions.ts`
+4. `src/chat/routeResolution.ts`
+
+Good first files to change:
+- `src/app.ts`
+- `src/routes/chatCompletions.ts`
+- `src/chat/routeResolution.ts`
+- focused tests in `src/*.test.ts`
+
+Higher complexity area:
+- `src/logExplainer/route.ts`
+- `src/logExplainer/logCollector.ts`
+- the rest of `src/logExplainer/`
+
+For quick validation, use `pnpm test` for the full suite, `pnpm run test:unit` for the smallest test loop, and `pnpm run test:integration` when you need route level coverage.
+
 ## Local Git Hooks
 - `pre-commit` formats staged JS/TS/JSON files with Biome and re-stages the formatted content before the commit completes.
 - `pre-push` checks files changed on the branch against `origin/main` and blocks the push if formatting drift remains.


### PR DESCRIPTION
## Summary
- add a short `First-time contributors` section to `README.md`
- document a recommended reading order for new contributors
- call out lower friction files versus the higher complexity `logExplainer` area
- include the minimum local install, test, and dev commands, including the local config file

## Why
- addresses issue #125 by making the repo easier to approach for first time contributors
- reduces ramp up time without duplicating the rest of the README

## Validation
- `BLACKICE_CONFIG_FILE=./config/blackice.local.yaml pnpm test` ✅ passed (`12` test files, `43` tests)

## Notes
- documentation only change
- keeps the guidance intentionally lightweight and points readers back to existing README sections for deeper detail
- closes #125
