### PR TITLE
feat: add execution intent lifecycle routes

### DIFF
--- a/BLACKICE_EXECUTION_BOUNDARY.md
+++ b/BLACKICE_EXECUTION_BOUNDARY.md
@@ -1,0 +1,86 @@
+# BlackIce Execution Boundary
+
+Issue [#139](https://github.com/redxzeta/blackice/issues/139) reframes BlackIce from an OpenClaw-facing policy router into the execution boundary for approved trading intents. This document captures the first implementation slice landed in this repository and the contract it establishes for follow-on work.
+
+## What this slice adds
+
+- A dedicated `/v1/intents` API for submitting, confirming, executing, cancelling, and listing trade intents.
+- Pre-execution policy enforcement for venue allowlist, max notional, daily notional budget, and TTL.
+- Signer and venue abstractions so custody and execution backends can be swapped without changing the route contract.
+- An append-only audit trail per intent covering submission, confirmation, signing, execution, and cancellation events.
+- Idempotent submission keyed by `idempotencyKey`.
+
+This is intentionally a minimal vertical slice. Persistence is currently in memory and the default signer and venue executor are mock implementations targeting a `paper` venue. That keeps the contract concrete while leaving KMS/HSM integration, durable storage, and real venue adapters for follow-up PRs.
+
+## Intent lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> submitted
+  submitted --> confirmed
+  submitted --> cancelled
+  confirmed --> execution_pending
+  confirmed --> cancelled
+  execution_pending --> executed
+  execution_pending --> confirmed: signer/execution failure
+```
+
+## API contract
+
+### `POST /v1/intents`
+
+Submit a pre-approved trade intent.
+
+```json
+{
+  "idempotencyKey": "trade-approval-123",
+  "accountId": "acct-primary",
+  "market": "BTC-USD",
+  "venue": "paper",
+  "side": "buy",
+  "quantity": 1,
+  "notionalUsd": 25000,
+  "ttlSeconds": 300
+}
+```
+
+Returns the canonical intent record plus the active policy snapshot. Repeating the same `idempotencyKey` returns the existing record instead of creating a duplicate.
+
+### `POST /v1/intents/:intentId/confirm`
+
+Moves an intent from `submitted` to `confirmed`. This separates orchestration approval from actual execution.
+
+### `POST /v1/intents/:intentId/execute`
+
+Requests signing and order placement. In this slice it uses:
+
+- `Signer.signIntent(intent)` to authorize signing
+- `VenueExecutor.placeOrder(intent)` to create a normalized order record
+
+Failures are recorded in the audit trail and leave the intent in `confirmed` so upstream systems can retry safely.
+
+### `POST /v1/intents/:intentId/cancel`
+
+Cancels a non-executed intent.
+
+### `GET /v1/intents`
+### `GET /v1/intents/:intentId`
+
+Expose the normalized intent state, associated orders, and audit trail for reconciliation and inspection.
+
+## Policy defaults in this slice
+
+- Allowed venues: `paper`
+- Max notional per intent: `$100,000`
+- Daily notional budget: `$250,000`
+- Max TTL: `86400` seconds
+
+These defaults are code-level placeholders for now. A follow-up PR should move them into runtime config.
+
+## Follow-on work
+
+- Persist intents, orders, and audit events durably.
+- Move policy thresholds and venue allowlists into runtime config.
+- Replace the mock signer with a KMS/HSM-backed implementation.
+- Add real venue adapters and a reconciliation loop for partial fills and cancels.
+- Emit dedicated structured metrics and logs for audit and retry analysis.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ OpenAI-compatible policy/router server for OpenClaw.
 - OpenClaw calls this server as its only provider.
 - This server routes to local Ollama models.
 - Supports CHAT (streaming) and ACTION (non-streaming) envelopes.
+- Includes a first execution-boundary slice for trade intents under `/v1/intents`.
 
 ## Architecture
 ```mermaid
@@ -66,6 +67,12 @@ pnpm run dev
 - `GET /analyze/logs/status`
 - `GET /analyze/logs/metadata`
 - `POST /v1/policy/dry-run`
+- `POST /v1/intents`
+- `POST /v1/intents/:intentId/confirm`
+- `POST /v1/intents/:intentId/execute`
+- `POST /v1/intents/:intentId/cancel`
+- `GET /v1/intents`
+- `GET /v1/intents/:intentId`
 - `GET /logs/recent` *(requires `ops.enabled: true` in the selected YAML config)*
 - `GET /logs/metrics` *(requires `ops.enabled: true` in the selected YAML config)*
 - `GET /metrics` *(requires `METRICS_ENABLED=1`, default enabled; path configurable via `METRICS_EXPOSE_PATH`)*
@@ -186,6 +193,8 @@ Run the full test suite:
 ```bash
 pnpm test
 ```
+
+Execution-boundary architecture notes live in `BLACKICE_EXECUTION_BOUNDARY.md`.
 
 Run only unit tests:
 ```bash

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { registerPolicyRoutes } from './routes/policy.js'
 import { registerDebateRoutes } from './routes/debate.js'
 import { registerModelRoutes } from './routes/models.js'
 import { registerOpsRoutes } from './routes/ops.js'
+import { registerIntentRoutes } from './routes/intents.js'
 import { checkReadiness, readinessStrict, readinessTimeoutMs } from './readiness.js'
 
 export function createApp(maxActiveDebates: number) {
@@ -28,6 +29,7 @@ export function createApp(maxActiveDebates: number) {
   registerDebateRoutes(app, maxActiveDebates)
   registerModelRoutes(app)
   registerOpsRoutes(app, versionInfo)
+  registerIntentRoutes(app)
 
   app.get('/readyz', async (_req, res) => {
     const readiness = await checkReadiness()

--- a/src/execution/schema.ts
+++ b/src/execution/schema.ts
@@ -1,0 +1,119 @@
+import { z } from 'zod'
+
+export const IntentStatusSchema = z.enum([
+  'submitted',
+  'confirmed',
+  'execution_pending',
+  'executed',
+  'cancelled',
+  'rejected',
+])
+
+export const OrderStatusSchema = z.enum(['pending', 'placed', 'filled', 'cancelled', 'failed'])
+
+export const AuditEventTypeSchema = z.enum([
+  'intent_submitted',
+  'intent_confirmed',
+  'intent_rejected',
+  'signing_requested',
+  'signing_succeeded',
+  'signing_failed',
+  'execution_requested',
+  'execution_succeeded',
+  'execution_failed',
+  'intent_cancelled',
+])
+
+export const ExecutionPolicySnapshotSchema = z.object({
+  maxNotionalUsd: z.number().positive(),
+  dailyNotionalLimitUsd: z.number().positive(),
+  allowedVenues: z.array(z.string().min(1)).min(1),
+  maxTtlSeconds: z.number().int().positive(),
+})
+
+export const SubmitIntentRequestSchema = z.object({
+  intentId: z.string().min(1).max(120).optional(),
+  idempotencyKey: z.string().min(1).max(120),
+  accountId: z.string().min(1).max(120),
+  market: z.string().min(3).max(64),
+  venue: z.string().min(1).max(64),
+  side: z.enum(['buy', 'sell']),
+  quantity: z.number().positive(),
+  limitPrice: z.number().positive().optional(),
+  notionalUsd: z.number().positive(),
+  ttlSeconds: z.number().int().min(1).max(86_400),
+  metadata: z.record(z.string(), z.unknown()).optional().default({}),
+})
+
+export const OrderRecordSchema = z.object({
+  orderId: z.string().min(1),
+  venue: z.string().min(1),
+  market: z.string().min(1),
+  side: z.enum(['buy', 'sell']),
+  quantity: z.number().positive(),
+  limitPrice: z.number().positive().optional(),
+  notionalUsd: z.number().positive(),
+  status: OrderStatusSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  externalOrderId: z.string().min(1).optional(),
+  failureReason: z.string().min(1).optional(),
+})
+
+export const AuditEventSchema = z.object({
+  eventId: z.string().min(1),
+  intentId: z.string().min(1),
+  type: AuditEventTypeSchema,
+  timestamp: z.string().datetime(),
+  requestId: z.string().min(1),
+  details: z.record(z.string(), z.unknown()).default({}),
+})
+
+export const IntentRecordSchema = z.object({
+  intentId: z.string().min(1),
+  idempotencyKey: z.string().min(1),
+  accountId: z.string().min(1),
+  market: z.string().min(1),
+  venue: z.string().min(1),
+  side: z.enum(['buy', 'sell']),
+  quantity: z.number().positive(),
+  limitPrice: z.number().positive().optional(),
+  notionalUsd: z.number().positive(),
+  ttlSeconds: z.number().int().positive(),
+  status: IntentStatusSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  confirmedAt: z.string().datetime().optional(),
+  executedAt: z.string().datetime().optional(),
+  cancelledAt: z.string().datetime().optional(),
+  rejectionReason: z.string().min(1).optional(),
+  metadata: z.record(z.string(), z.unknown()).default({}),
+  signerRef: z.string().min(1).optional(),
+  orders: z.array(OrderRecordSchema).default([]),
+  auditTrail: z.array(AuditEventSchema).default([]),
+})
+
+export const SubmitIntentResponseSchema = z.object({
+  ok: z.literal(true),
+  created: z.boolean(),
+  intent: IntentRecordSchema,
+  policy: ExecutionPolicySnapshotSchema,
+})
+
+export const IntentActionResponseSchema = z.object({
+  ok: z.literal(true),
+  intent: IntentRecordSchema,
+})
+
+export const ListIntentsResponseSchema = z.object({
+  ok: z.literal(true),
+  intents: z.array(IntentRecordSchema),
+})
+
+export type SubmitIntentRequest = z.input<typeof SubmitIntentRequestSchema>
+export type ExecutionPolicySnapshot = z.infer<typeof ExecutionPolicySnapshotSchema>
+export type IntentRecord = z.infer<typeof IntentRecordSchema>
+export type OrderRecord = z.infer<typeof OrderRecordSchema>
+export type AuditEvent = z.infer<typeof AuditEventSchema>
+export type IntentStatus = z.infer<typeof IntentStatusSchema>

--- a/src/execution/service.test.ts
+++ b/src/execution/service.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+import { ExecutionPolicyError, ExecutionService, IntentStateError } from './service.js'
+
+function buildService() {
+  let currentTime = Date.parse('2026-04-18T12:00:00.000Z')
+  const service = new ExecutionService({
+    now: () => new Date(currentTime),
+  })
+
+  return {
+    service,
+    advanceTime(ms: number) {
+      currentTime += ms
+    },
+  }
+}
+
+const validIntent = {
+  idempotencyKey: 'idem-1',
+  accountId: 'acct-1',
+  market: 'BTC-USD',
+  venue: 'paper',
+  side: 'buy' as const,
+  quantity: 1,
+  notionalUsd: 10_000,
+  ttlSeconds: 300,
+}
+
+describe('ExecutionService', () => {
+  it('supports idempotent submit retries', () => {
+    const { service } = buildService()
+
+    const first = service.submitIntent(validIntent, 'req-1')
+    const second = service.submitIntent(validIntent, 'req-2')
+
+    expect(first.created).toBe(true)
+    expect(second.created).toBe(false)
+    expect(second.intent.intentId).toBe(first.intent.intentId)
+  })
+
+  it('rejects policy violations', () => {
+    const { service } = buildService()
+
+    expect(() =>
+      service.submitIntent(
+        {
+          ...validIntent,
+          idempotencyKey: 'idem-2',
+          venue: 'binance',
+        },
+        'req-1'
+      )
+    ).toThrowError(ExecutionPolicyError)
+  })
+
+  it('rejects idempotency key reuse when the payload changes', () => {
+    const { service } = buildService()
+
+    service.submitIntent(validIntent, 'req-1')
+
+    expect(() =>
+      service.submitIntent(
+        {
+          ...validIntent,
+          notionalUsd: 15_000,
+        },
+        'req-2'
+      )
+    ).toThrowError(IntentStateError)
+  })
+
+  it('records signer failures and keeps intent confirmable', async () => {
+    const service = new ExecutionService({
+      signer: {
+        async signIntent() {
+          throw new Error('signer offline')
+        },
+      },
+    })
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+
+    await expect(service.executeIntent(intent.intentId, 'req-3')).rejects.toThrow('signer offline')
+
+    const stored = service.getIntent(intent.intentId)
+    expect(stored.status).toBe('confirmed')
+    expect(stored.auditTrail.at(-1)?.type).toBe('signing_failed')
+  })
+
+  it('records execution failures and keeps intent confirmed for retry', async () => {
+    const service = new ExecutionService({
+      venueExecutor: {
+        async placeOrder() {
+          throw new Error('venue rejected order')
+        },
+      },
+    })
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+
+    await expect(service.executeIntent(intent.intentId, 'req-3')).rejects.toThrow(
+      'venue rejected order'
+    )
+
+    const stored = service.getIntent(intent.intentId)
+    expect(stored.status).toBe('confirmed')
+    expect(stored.auditTrail.at(-1)?.type).toBe('execution_failed')
+  })
+
+  it('blocks execution after ttl expiry', async () => {
+    const { service, advanceTime } = buildService()
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+    advanceTime(301_000)
+
+    await expect(service.executeIntent(intent.intentId, 'req-3')).rejects.toThrow(
+      ExecutionPolicyError
+    )
+  })
+
+  it('prevents cancellation after execution', async () => {
+    const { service } = buildService()
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+    await service.executeIntent(intent.intentId, 'req-3')
+
+    expect(() => service.cancelIntent(intent.intentId, 'req-4')).toThrowError(IntentStateError)
+  })
+})

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -1,0 +1,350 @@
+import { randomUUID } from 'node:crypto'
+import {
+  type AuditEvent,
+  AuditEventSchema,
+  type ExecutionPolicySnapshot,
+  type IntentRecord,
+  IntentRecordSchema,
+  type OrderRecord,
+  OrderRecordSchema,
+  type SubmitIntentRequest,
+} from './schema.js'
+
+export class ExecutionPolicyError extends Error {
+  status = 422
+
+  constructor(
+    message: string,
+    readonly code: string
+  ) {
+    super(message)
+    this.name = 'ExecutionPolicyError'
+  }
+}
+
+export class IntentStateError extends Error {
+  status = 409
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'IntentStateError'
+  }
+}
+
+export class IntentNotFoundError extends Error {
+  status = 404
+
+  constructor(intentId: string) {
+    super(`Intent not found: ${intentId}`)
+    this.name = 'IntentNotFoundError'
+  }
+}
+
+export type Signer = {
+  signIntent(intent: IntentRecord): Promise<{ signerRef: string }>
+}
+
+export type VenueExecutor = {
+  placeOrder(
+    intent: IntentRecord
+  ): Promise<{ externalOrderId: string; status: OrderRecord['status'] }>
+}
+
+type ExecutionServiceOptions = {
+  policy?: ExecutionPolicySnapshot
+  signer?: Signer
+  venueExecutor?: VenueExecutor
+  now?: () => Date
+}
+
+const DEFAULT_POLICY: ExecutionPolicySnapshot = {
+  maxNotionalUsd: 100_000,
+  dailyNotionalLimitUsd: 250_000,
+  allowedVenues: ['paper'],
+  maxTtlSeconds: 86_400,
+}
+
+class InMemorySigner implements Signer {
+  async signIntent(intent: IntentRecord): Promise<{ signerRef: string }> {
+    return { signerRef: `local-signer:${intent.intentId}` }
+  }
+}
+
+class InMemoryVenueExecutor implements VenueExecutor {
+  async placeOrder(
+    intent: IntentRecord
+  ): Promise<{ externalOrderId: string; status: OrderRecord['status'] }> {
+    return {
+      externalOrderId: `paper-${intent.intentId}`,
+      status: 'filled',
+    }
+  }
+}
+
+export class ExecutionService {
+  private readonly intents = new Map<string, IntentRecord>()
+  private readonly idempotencyKeys = new Map<string, string>()
+  private readonly policy: ExecutionPolicySnapshot
+  private readonly signer: Signer
+  private readonly venueExecutor: VenueExecutor
+  private readonly now: () => Date
+
+  constructor(options: ExecutionServiceOptions = {}) {
+    this.policy = options.policy ?? DEFAULT_POLICY
+    this.signer = options.signer ?? new InMemorySigner()
+    this.venueExecutor = options.venueExecutor ?? new InMemoryVenueExecutor()
+    this.now = options.now ?? (() => new Date())
+  }
+
+  getPolicy(): ExecutionPolicySnapshot {
+    return this.policy
+  }
+
+  listIntents(status?: IntentRecord['status']): IntentRecord[] {
+    const intents = Array.from(this.intents.values())
+    return status ? intents.filter((intent) => intent.status === status) : intents
+  }
+
+  getIntent(intentId: string): IntentRecord {
+    const intent = this.intents.get(intentId)
+    if (!intent) {
+      throw new IntentNotFoundError(intentId)
+    }
+    return intent
+  }
+
+  submitIntent(
+    input: SubmitIntentRequest,
+    requestId: string
+  ): { created: boolean; intent: IntentRecord } {
+    const existingIntentId = this.idempotencyKeys.get(input.idempotencyKey)
+    if (existingIntentId) {
+      const existingIntent = this.getIntent(existingIntentId)
+      if (!this.matchesExistingIntent(existingIntent, input)) {
+        throw new IntentStateError(
+          `Idempotency key ${input.idempotencyKey} conflicts with an existing intent payload`
+        )
+      }
+      return {
+        created: false,
+        intent: existingIntent,
+      }
+    }
+
+    this.validatePolicy(input)
+
+    const nowIso = this.now().toISOString()
+    const intentId = input.intentId ?? randomUUID()
+    if (this.intents.has(intentId)) {
+      throw new IntentStateError(`Intent already exists: ${intentId}`)
+    }
+
+    const intent = IntentRecordSchema.parse({
+      intentId,
+      idempotencyKey: input.idempotencyKey,
+      accountId: input.accountId,
+      market: input.market,
+      venue: input.venue,
+      side: input.side,
+      quantity: input.quantity,
+      limitPrice: input.limitPrice,
+      notionalUsd: input.notionalUsd,
+      ttlSeconds: input.ttlSeconds,
+      status: 'submitted',
+      createdAt: nowIso,
+      updatedAt: nowIso,
+      expiresAt: new Date(Date.parse(nowIso) + input.ttlSeconds * 1000).toISOString(),
+      metadata: input.metadata,
+      orders: [],
+      auditTrail: [],
+    })
+
+    this.appendAuditEvent(intent, 'intent_submitted', requestId, {
+      accountId: input.accountId,
+      venue: input.venue,
+      market: input.market,
+      notionalUsd: input.notionalUsd,
+    })
+
+    this.intents.set(intent.intentId, intent)
+    this.idempotencyKeys.set(input.idempotencyKey, intent.intentId)
+
+    return { created: true, intent }
+  }
+
+  confirmIntent(intentId: string, requestId: string): IntentRecord {
+    const intent = this.getIntent(intentId)
+    if (intent.status === 'confirmed' || intent.status === 'executed') {
+      return intent
+    }
+    if (intent.status !== 'submitted') {
+      throw new IntentStateError(
+        `Intent ${intentId} cannot be confirmed from status ${intent.status}`
+      )
+    }
+
+    const nowIso = this.now().toISOString()
+    intent.status = 'confirmed'
+    intent.confirmedAt = nowIso
+    intent.updatedAt = nowIso
+    this.appendAuditEvent(intent, 'intent_confirmed', requestId, {})
+    return intent
+  }
+
+  async executeIntent(intentId: string, requestId: string): Promise<IntentRecord> {
+    const intent = this.getIntent(intentId)
+    if (intent.status === 'executed') {
+      return intent
+    }
+    if (intent.status !== 'confirmed') {
+      throw new IntentStateError(`Intent ${intentId} cannot execute from status ${intent.status}`)
+    }
+    if (Date.parse(intent.expiresAt) < this.now().getTime()) {
+      throw new ExecutionPolicyError(
+        `Intent ${intentId} expired before execution`,
+        'intent_expired'
+      )
+    }
+
+    const requestedAt = this.now().toISOString()
+    intent.status = 'execution_pending'
+    intent.updatedAt = requestedAt
+    this.appendAuditEvent(intent, 'signing_requested', requestId, {})
+
+    try {
+      const signed = await this.signer.signIntent(intent)
+      intent.signerRef = signed.signerRef
+      this.appendAuditEvent(intent, 'signing_succeeded', requestId, {
+        signerRef: signed.signerRef,
+      })
+    } catch (error) {
+      intent.status = 'confirmed'
+      intent.updatedAt = this.now().toISOString()
+      this.appendAuditEvent(intent, 'signing_failed', requestId, {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      throw error
+    }
+
+    this.appendAuditEvent(intent, 'execution_requested', requestId, {})
+
+    try {
+      const execution = await this.venueExecutor.placeOrder(intent)
+      const nowIso = this.now().toISOString()
+      const order = OrderRecordSchema.parse({
+        orderId: randomUUID(),
+        venue: intent.venue,
+        market: intent.market,
+        side: intent.side,
+        quantity: intent.quantity,
+        limitPrice: intent.limitPrice,
+        notionalUsd: intent.notionalUsd,
+        status: execution.status,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+        externalOrderId: execution.externalOrderId,
+      })
+
+      intent.orders.push(order)
+      intent.status = 'executed'
+      intent.executedAt = nowIso
+      intent.updatedAt = nowIso
+      this.appendAuditEvent(intent, 'execution_succeeded', requestId, {
+        externalOrderId: execution.externalOrderId,
+        orderStatus: execution.status,
+      })
+      return intent
+    } catch (error) {
+      const nowIso = this.now().toISOString()
+      intent.status = 'confirmed'
+      intent.updatedAt = nowIso
+      this.appendAuditEvent(intent, 'execution_failed', requestId, {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      throw error
+    }
+  }
+
+  cancelIntent(intentId: string, requestId: string): IntentRecord {
+    const intent = this.getIntent(intentId)
+    if (intent.status === 'cancelled') {
+      return intent
+    }
+    if (intent.status === 'executed') {
+      throw new IntentStateError(`Intent ${intentId} cannot be cancelled after execution`)
+    }
+
+    const nowIso = this.now().toISOString()
+    intent.status = 'cancelled'
+    intent.cancelledAt = nowIso
+    intent.updatedAt = nowIso
+    this.appendAuditEvent(intent, 'intent_cancelled', requestId, {})
+    return intent
+  }
+
+  private validatePolicy(input: SubmitIntentRequest): void {
+    if (!this.policy.allowedVenues.includes(input.venue)) {
+      throw new ExecutionPolicyError(
+        `Venue ${input.venue} is not allowed by policy`,
+        'venue_not_allowed'
+      )
+    }
+    if (input.notionalUsd > this.policy.maxNotionalUsd) {
+      throw new ExecutionPolicyError(
+        `Intent notional ${input.notionalUsd} exceeds max ${this.policy.maxNotionalUsd}`,
+        'max_notional_exceeded'
+      )
+    }
+    if (input.ttlSeconds > this.policy.maxTtlSeconds) {
+      throw new ExecutionPolicyError(
+        `Intent ttlSeconds ${input.ttlSeconds} exceeds max ${this.policy.maxTtlSeconds}`,
+        'ttl_exceeded'
+      )
+    }
+
+    const windowStart = this.now()
+    windowStart.setUTCHours(0, 0, 0, 0)
+    const todayNotional = Array.from(this.intents.values())
+      .filter((intent) => Date.parse(intent.createdAt) >= windowStart.getTime())
+      .reduce((total, intent) => total + intent.notionalUsd, 0)
+
+    if (todayNotional + input.notionalUsd > this.policy.dailyNotionalLimitUsd) {
+      throw new ExecutionPolicyError(
+        `Daily notional limit ${this.policy.dailyNotionalLimitUsd} would be exceeded`,
+        'daily_notional_limit_exceeded'
+      )
+    }
+  }
+
+  private appendAuditEvent(
+    intent: IntentRecord,
+    type: AuditEvent['type'],
+    requestId: string,
+    details: Record<string, unknown>
+  ): void {
+    intent.auditTrail.push(
+      AuditEventSchema.parse({
+        eventId: randomUUID(),
+        intentId: intent.intentId,
+        type,
+        timestamp: this.now().toISOString(),
+        requestId,
+        details,
+      })
+    )
+  }
+
+  private matchesExistingIntent(intent: IntentRecord, input: SubmitIntentRequest): boolean {
+    return (
+      intent.accountId === input.accountId &&
+      intent.market === input.market &&
+      intent.venue === input.venue &&
+      intent.side === input.side &&
+      intent.quantity === input.quantity &&
+      intent.limitPrice === input.limitPrice &&
+      intent.notionalUsd === input.notionalUsd &&
+      intent.ttlSeconds === input.ttlSeconds &&
+      JSON.stringify(intent.metadata) === JSON.stringify(input.metadata ?? {})
+    )
+  }
+}

--- a/src/routes.integration.test.ts
+++ b/src/routes.integration.test.ts
@@ -214,6 +214,95 @@ describe('integration routes', () => {
     expect(res.body.route).toBeDefined()
   })
 
+  it('POST /v1/intents creates and returns an intent record', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1)
+
+    const res = await request(app).post('/v1/intents').send({
+      idempotencyKey: 'idem-http-1',
+      accountId: 'acct-primary',
+      market: 'BTC-USD',
+      venue: 'paper',
+      side: 'buy',
+      quantity: 1,
+      notionalUsd: 12000,
+      ttlSeconds: 300,
+    })
+
+    expect(res.status).toBe(201)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.intent.status).toBe('submitted')
+    expect(res.body.policy.allowedVenues).toContain('paper')
+  })
+
+  it('POST /v1/intents is idempotent on repeated idempotency keys', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1)
+    const payload = {
+      idempotencyKey: 'idem-http-2',
+      accountId: 'acct-primary',
+      market: 'ETH-USD',
+      venue: 'paper',
+      side: 'sell',
+      quantity: 2,
+      notionalUsd: 6000,
+      ttlSeconds: 300,
+    }
+
+    const first = await request(app).post('/v1/intents').send(payload)
+    const second = await request(app).post('/v1/intents').send(payload)
+
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(200)
+    expect(second.body.created).toBe(false)
+    expect(second.body.intent.intentId).toBe(first.body.intent.intentId)
+  })
+
+  it('POST /v1/intents/:intentId/confirm and /execute complete the lifecycle', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1)
+
+    const submit = await request(app).post('/v1/intents').send({
+      idempotencyKey: 'idem-http-3',
+      accountId: 'acct-primary',
+      market: 'SOL-USD',
+      venue: 'paper',
+      side: 'buy',
+      quantity: 10,
+      notionalUsd: 1500,
+      ttlSeconds: 300,
+    })
+    const intentId = submit.body.intent.intentId
+
+    const confirm = await request(app).post(`/v1/intents/${intentId}/confirm`).send({})
+    const execute = await request(app).post(`/v1/intents/${intentId}/execute`).send({})
+
+    expect(confirm.status).toBe(200)
+    expect(confirm.body.intent.status).toBe('confirmed')
+    expect(execute.status).toBe(200)
+    expect(execute.body.intent.status).toBe('executed')
+    expect(execute.body.intent.orders).toHaveLength(1)
+  })
+
+  it('POST /v1/intents rejects disallowed venues', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1)
+
+    const res = await request(app).post('/v1/intents').send({
+      idempotencyKey: 'idem-http-4',
+      accountId: 'acct-primary',
+      market: 'BTC-USD',
+      venue: 'kraken',
+      side: 'buy',
+      quantity: 1,
+      notionalUsd: 1000,
+      ttlSeconds: 300,
+    })
+
+    expect(res.status).toBe(422)
+    expect(res.body.code).toBe('venue_not_allowed')
+  })
+
   it('POST /analyze/logs returns validation error for bad payload', async () => {
     const { createApp } = await import('./app.js')
     const app = createApp(1)

--- a/src/routes/intents.ts
+++ b/src/routes/intents.ts
@@ -1,0 +1,134 @@
+import type { Express, Request, Response } from 'express'
+import { log } from '../log.js'
+import { sendSimpleError } from '../http/errors.js'
+import { parseBodyOrRespond } from '../http/validation.js'
+import { getRequestId } from '../http/requestLogging.js'
+import {
+  ExecutionPolicyError,
+  ExecutionService,
+  IntentNotFoundError,
+  IntentStateError,
+} from '../execution/service.js'
+import {
+  IntentActionResponseSchema,
+  IntentStatusSchema,
+  ListIntentsResponseSchema,
+  SubmitIntentRequestSchema,
+  SubmitIntentResponseSchema,
+} from '../execution/schema.js'
+
+export function registerIntentRoutes(
+  app: Express,
+  executionService = new ExecutionService()
+): void {
+  app.post('/v1/intents', (req: Request, res: Response) => {
+    const requestId = getRequestId(res)
+    const parsed = parseBodyOrRespond(SubmitIntentRequestSchema, req.body, res)
+    if (!parsed) {
+      return
+    }
+
+    try {
+      const result = executionService.submitIntent(parsed, requestId)
+      log.info('intent_submitted', {
+        request_id: requestId,
+        intent_id: result.intent.intentId,
+        created: result.created,
+        venue: result.intent.venue,
+        market: result.intent.market,
+        notional_usd: result.intent.notionalUsd,
+      })
+      res.status(result.created ? 201 : 200).json(
+        SubmitIntentResponseSchema.parse({
+          ok: true,
+          created: result.created,
+          intent: result.intent,
+          policy: executionService.getPolicy(),
+        })
+      )
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
+  app.get('/v1/intents', (req: Request, res: Response) => {
+    const rawStatus = typeof req.query.status === 'string' ? req.query.status : undefined
+    const parsedStatus = IntentStatusSchema.safeParse(rawStatus)
+
+    const intents = executionService.listIntents(
+      parsedStatus.success ? parsedStatus.data : undefined
+    )
+
+    res.status(200).json(
+      ListIntentsResponseSchema.parse({
+        ok: true,
+        intents,
+      })
+    )
+  })
+
+  app.get('/v1/intents/:intentId', (req: Request, res: Response) => {
+    try {
+      res.status(200).json(
+        IntentActionResponseSchema.parse({
+          ok: true,
+          intent: executionService.getIntent(req.params.intentId),
+        })
+      )
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
+  app.post('/v1/intents/:intentId/confirm', (req: Request, res: Response) => {
+    try {
+      const requestId = getRequestId(res)
+      const intent = executionService.confirmIntent(req.params.intentId, requestId)
+      res.status(200).json(IntentActionResponseSchema.parse({ ok: true, intent }))
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
+  app.post('/v1/intents/:intentId/execute', async (req: Request, res: Response) => {
+    try {
+      const requestId = getRequestId(res)
+      const intent = await executionService.executeIntent(req.params.intentId, requestId)
+      res.status(200).json(IntentActionResponseSchema.parse({ ok: true, intent }))
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
+  app.post('/v1/intents/:intentId/cancel', (req: Request, res: Response) => {
+    try {
+      const requestId = getRequestId(res)
+      const intent = executionService.cancelIntent(req.params.intentId, requestId)
+      res.status(200).json(IntentActionResponseSchema.parse({ ok: true, intent }))
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+}
+
+function respondExecutionError(res: Response, error: unknown): void {
+  if (error instanceof IntentNotFoundError) {
+    sendSimpleError(res, 404, error.message)
+    return
+  }
+
+  if (error instanceof IntentStateError) {
+    sendSimpleError(res, 409, error.message)
+    return
+  }
+
+  if (error instanceof ExecutionPolicyError) {
+    res.status(error.status).json({
+      error: error.message,
+      code: error.code,
+    })
+    return
+  }
+
+  sendSimpleError(res, 500, error instanceof Error ? error.message : 'Internal server error')
+}


### PR DESCRIPTION
## Summary
- add a first execution-boundary slice with /v1/intents submit/confirm/execute/cancel/list routes
- enforce basic trade policy checks, idempotency safety, and append-only per-intent audit events
- document the architecture slice and add integration/service tests for policy rejection, retries, and failure paths

## Testing
- pnpm run build
- pnpm run lint
- pnpm test -- src/execution/service.test.ts src/routes.integration.test.ts

Closes #139