### PR TITLE
test(logExplainer): add focused Loki coverage

### DIFF
--- a/src/logExplainer/evidence.test.ts
+++ b/src/logExplainer/evidence.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tempDirs: string[] = []
+
+function writeRuntimeConfig(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-evidence-test-'))
+  const configFile = path.join(dir, 'blackice.test.yaml')
+  const rulesFile = path.join(dir, 'loki-rules.yaml')
+
+  writeFileSync(
+    configFile,
+    `version: 1
+loki:
+  baseUrl: http://127.0.0.1:3100
+  rulesFile: ./loki-rules.yaml
+`
+  )
+writeFileSync(
+    rulesFile,
+    `allowedLabels:
+  - job
+  - host
+  - unit
+  - app
+hosts:
+  - node-1
+`
+  )
+
+  tempDirs.push(dir)
+  return configFile
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('log explainer evidence', () => {
+  it('samples the newest lines, redacts secrets, and truncates long evidence', async () => {
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+    const { buildEvidence } = await import('./evidence.js')
+
+    const evidence = buildEvidence(
+      [
+        '2026-04-18T12:00:00Z old line',
+        '1744987200000000000 authorization: Bearer abc123',
+        'x'.repeat(2100),
+      ].join('\n'),
+      2
+    )
+
+    expect(evidence).toHaveLength(2)
+    expect(evidence?.[0]).toEqual({
+      ts: '1744987200000000000',
+      line: 'authorization: Bearer [REDACTED]',
+    })
+    expect(evidence?.[1].ts).toBe('')
+    expect(evidence?.[1].line.startsWith('x'.repeat(2000))).toBe(true)
+    expect(evidence?.[1].line.endsWith(' [truncated]')).toBe(true)
+  })
+})

--- a/src/logExplainer/evidence.test.ts
+++ b/src/logExplainer/evidence.test.ts
@@ -18,7 +18,7 @@ loki:
   rulesFile: ./loki-rules.yaml
 `
   )
-writeFileSync(
+  writeFileSync(
     rulesFile,
     `allowedLabels:
   - job

--- a/src/logExplainer/evidence.ts
+++ b/src/logExplainer/evidence.ts
@@ -1,0 +1,61 @@
+import { BATCH_EVIDENCE_LINES_MAX } from './schema.js'
+import { sanitizeReadOnlyEvidenceLine } from './outputSafety.js'
+
+export type EvidenceLine = {
+  ts: string
+  line: string
+}
+
+export const MAX_EVIDENCE_LINE_CHARS = 2_000
+
+function clampEvidenceLine(line: string): string {
+  if (line.length <= MAX_EVIDENCE_LINE_CHARS) {
+    return line
+  }
+  return `${line.slice(0, MAX_EVIDENCE_LINE_CHARS)} [truncated]`
+}
+
+export function parseEvidenceLine(rawLine: string): EvidenceLine {
+  const ISO_OR_SHORT_TS_PREFIX = /^(\d{4}-\d{2}-\d{2}[ T][^\s]+)\s+(.*)$/
+  const LOKI_NS_TS_PREFIX = /^(\d{16,20})\s+(.*)$/
+  const trimmed = rawLine.trim()
+
+  const isoMatch = trimmed.match(ISO_OR_SHORT_TS_PREFIX)
+  if (isoMatch) {
+    return {
+      ts: isoMatch[1],
+      line: clampEvidenceLine(sanitizeReadOnlyEvidenceLine(isoMatch[2])),
+    }
+  }
+
+  const lokiMatch = trimmed.match(LOKI_NS_TS_PREFIX)
+  if (lokiMatch) {
+    return {
+      ts: lokiMatch[1],
+      line: clampEvidenceLine(sanitizeReadOnlyEvidenceLine(lokiMatch[2])),
+    }
+  }
+
+  return {
+    ts: '',
+    line: clampEvidenceLine(sanitizeReadOnlyEvidenceLine(trimmed)),
+  }
+}
+
+export function buildEvidence(
+  rawLogs: string,
+  requestedLines: number | undefined
+): EvidenceLine[] | undefined {
+  if (requestedLines === undefined) {
+    return undefined
+  }
+
+  const boundedCount = Math.max(1, Math.min(requestedLines, BATCH_EVIDENCE_LINES_MAX))
+  const lines = rawLogs
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0)
+
+  const sampled = lines.slice(-boundedCount)
+  return sampled.map((line) => parseEvidenceLine(line))
+}

--- a/src/logExplainer/logCollector.test.ts
+++ b/src/logExplainer/logCollector.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tempDirs: string[] = []
+
+function writeRuntimeConfig(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-loki-test-'))
+  const configFile = path.join(dir, 'blackice.test.yaml')
+  const rulesFile = path.join(dir, 'loki-rules.yaml')
+
+  writeFileSync(
+    configFile,
+    `version: 1
+loki:
+  baseUrl: http://127.0.0.1:3100
+  rulesFile: ./loki-rules.yaml
+`
+  )
+writeFileSync(
+    rulesFile,
+    `allowedLabels:
+  - job
+  - host
+  - unit
+  - app
+hosts:
+  - node-1
+units:
+  - blackice.service
+`
+  )
+
+  tempDirs.push(dir)
+  return configFile
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('log explainer Loki helpers', () => {
+  it('normalizes selectors, escapes filters, and returns sorted Loki output', async () => {
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: 'success',
+          data: {
+            resultType: 'streams',
+            result: [
+              {
+                stream: { unit: 'blackice.service', host: 'node-1' },
+                values: [
+                  ['2000000', 'second'],
+                  ['1000000', 'first'],
+                ],
+              },
+            ],
+          },
+        }),
+      })
+    )
+
+    const { buildEffectiveLokiQuery, collectLokiBatchLogs } = await import('./logCollector.js')
+
+    expect(
+      buildEffectiveLokiQuery({
+        source: 'loki',
+        filters: { job: 'blackice', host: 'node-1', app: 'api' },
+        contains: 'foo "bar" \\ baz',
+        regex: 'error\\d+',
+      })
+    ).toBe('{app="api",host="node-1",job="blackice"} |= "foo \\\"bar\\\" \\\\ baz" |~ "error\\\\d+"')
+
+    const result = await collectLokiBatchLogs({
+      source: 'loki',
+      filters: { job: 'blackice', host: 'node-1', app: 'api' },
+      contains: 'hello',
+      limit: 10,
+    })
+
+    expect(result.query).toBe('{app="api",host="node-1",job="blackice"} |= "hello"')
+    expect(result.logs).toContain('1970-01-01T00:00:00.001Z [host=node-1,unit=blackice.service] first')
+    expect(result.logs).toContain('1970-01-01T00:00:00.002Z [host=node-1,unit=blackice.service] second')
+  })
+
+  it('rejects unscoped Loki filters before issuing a query', async () => {
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+    const { collectLokiBatchLogs } = await import('./logCollector.js')
+
+    await expect(
+      collectLokiBatchLogs({
+        source: 'loki',
+        filters: { job: 'blackice', app: 'api' },
+        limit: 10,
+      })
+    ).rejects.toThrow('Loki query must include host or unit label')
+  })
+
+  it('resolves sinceSeconds windows from the current clock', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-18T12:00:00Z'))
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+    const { resolveLokiTimeRange } = await import('./logCollector.js')
+
+    const range = resolveLokiTimeRange({ sinceSeconds: 90 })
+
+    expect(range.hours).toBeCloseTo(0.025, 6)
+    expect(BigInt(range.endNs) - BigInt(range.startNs)).toBe(90_000_000_000n)
+  })
+})

--- a/src/logExplainer/logCollector.test.ts
+++ b/src/logExplainer/logCollector.test.ts
@@ -18,7 +18,7 @@ loki:
   rulesFile: ./loki-rules.yaml
 `
   )
-writeFileSync(
+  writeFileSync(
     rulesFile,
     `allowedLabels:
   - job
@@ -84,7 +84,7 @@ describe('log explainer Loki helpers', () => {
         contains: 'foo "bar" \\ baz',
         regex: 'error\\d+',
       })
-    ).toBe('{app="api",host="node-1",job="blackice"} |= "foo \\\"bar\\\" \\\\ baz" |~ "error\\\\d+"')
+    ).toBe('{app="api",host="node-1",job="blackice"} |= "foo \\"bar\\" \\\\ baz" |~ "error\\\\d+"')
 
     const result = await collectLokiBatchLogs({
       source: 'loki',
@@ -94,8 +94,12 @@ describe('log explainer Loki helpers', () => {
     })
 
     expect(result.query).toBe('{app="api",host="node-1",job="blackice"} |= "hello"')
-    expect(result.logs).toContain('1970-01-01T00:00:00.001Z [host=node-1,unit=blackice.service] first')
-    expect(result.logs).toContain('1970-01-01T00:00:00.002Z [host=node-1,unit=blackice.service] second')
+    expect(result.logs).toContain(
+      '1970-01-01T00:00:00.001Z [host=node-1,unit=blackice.service] first'
+    )
+    expect(result.logs).toContain(
+      '1970-01-01T00:00:00.002Z [host=node-1,unit=blackice.service] second'
+    )
   })
 
   it('rejects unscoped Loki filters before issuing a query', async () => {

--- a/src/logExplainer/route.ts
+++ b/src/logExplainer/route.ts
@@ -33,8 +33,8 @@ import {
   ensureReadOnlyAnalysisOutput,
   redactSecrets,
   sanitizeReadOnlyAnalysisOutput,
-  sanitizeReadOnlyEvidenceLine,
 } from './outputSafety.js'
+import { buildEvidence } from './evidence.js'
 import { errMessage, toHttpError } from '../http/errors.js'
 import { getRequestId } from '../http/requestLogging.js'
 import { parseBodyOrRespond } from '../http/validation.js'
@@ -52,14 +52,6 @@ type AnalysisResult = {
 }
 
 type BatchMode = 'analyze' | 'raw' | 'both'
-type EvidenceLine = {
-  ts: string
-  line: string
-}
-
-const ISO_OR_SHORT_TS_PREFIX = /^(\d{4}-\d{2}-\d{2}[ T][^\s]+)\s+(.*)$/
-const LOKI_NS_TS_PREFIX = /^(\d{16,20})\s+(.*)$/
-const MAX_EVIDENCE_LINE_CHARS = 2_000
 const RATE_LIMIT_RESPONSE_TYPE = 'rate_limit_exceeded'
 const RATE_LIMIT_POLICIES: Record<'analyze' | 'batch', RateLimitPolicy> = {
   analyze: {
@@ -76,56 +68,6 @@ const RATE_LIMIT_POLICIES: Record<'analyze' | 'batch', RateLimitPolicy> = {
   },
 }
 const rateLimitBuckets = new Map<string, RateLimitBucket>()
-
-function clampEvidenceLine(line: string): string {
-  if (line.length <= MAX_EVIDENCE_LINE_CHARS) {
-    return line
-  }
-  return `${line.slice(0, MAX_EVIDENCE_LINE_CHARS)} [truncated]`
-}
-
-function parseEvidenceLine(rawLine: string): EvidenceLine {
-  const trimmed = rawLine.trim()
-
-  const isoMatch = trimmed.match(ISO_OR_SHORT_TS_PREFIX)
-  if (isoMatch) {
-    return {
-      ts: isoMatch[1],
-      line: clampEvidenceLine(sanitizeReadOnlyEvidenceLine(isoMatch[2])),
-    }
-  }
-
-  const lokiMatch = trimmed.match(LOKI_NS_TS_PREFIX)
-  if (lokiMatch) {
-    return {
-      ts: lokiMatch[1],
-      line: clampEvidenceLine(sanitizeReadOnlyEvidenceLine(lokiMatch[2])),
-    }
-  }
-
-  return {
-    ts: '',
-    line: clampEvidenceLine(sanitizeReadOnlyEvidenceLine(trimmed)),
-  }
-}
-
-function buildEvidence(
-  rawLogs: string,
-  requestedLines: number | undefined
-): EvidenceLine[] | undefined {
-  if (requestedLines === undefined) {
-    return undefined
-  }
-
-  const boundedCount = Math.max(1, Math.min(requestedLines, BATCH_EVIDENCE_LINES_MAX))
-  const lines = rawLogs
-    .split('\n')
-    .map((line) => line.trimEnd())
-    .filter((line) => line.trim().length > 0)
-
-  const sampled = lines.slice(-boundedCount)
-  return sampled.map((line) => parseEvidenceLine(line))
-}
 
 function resolveBatchMode(input: { mode?: BatchMode; analyze?: boolean; collectOnly?: boolean }): {
   mode: BatchMode


### PR DESCRIPTION
Adds a small evidence helper extraction plus focused Loki selector, guard, and evidence formatting tests for #126.