### PR TITLE
feat(issue-143): add foundation config and execution contracts

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -291,10 +291,12 @@ export function getRuntimeConfig(): RuntimeConfig {
     excludedEventTypes: marketDataYaml.excludedEventTypes ?? [],
   }
 
+  const defaultVenue = String(executionYaml.defaultVenue ?? DEFAULT_EXECUTION_DEFAULT_VENUE).trim()
+
   const execution = {
-    defaultVenue: String(executionYaml.defaultVenue ?? DEFAULT_EXECUTION_DEFAULT_VENUE).trim(),
+    defaultVenue,
     allowedVenues: executionYaml.allowedVenues?.map((venue) => venue.trim()).filter(Boolean) ?? [
-      DEFAULT_EXECUTION_DEFAULT_VENUE,
+      defaultVenue,
     ],
     requirePreflight: executionYaml.requirePreflight ?? DEFAULT_EXECUTION_REQUIRE_PREFLIGHT,
     maxPositionUsd: executionYaml.maxPositionUsd ?? DEFAULT_EXECUTION_MAX_POSITION_USD,

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -27,6 +27,15 @@ const DEFAULT_OLLAMA_RETRY_BACKOFF_MS = 1_000
 const DEFAULT_LOKI_MAX_WINDOW_MINUTES = 60
 const DEFAULT_LOKI_DEFAULT_WINDOW_MINUTES = 15
 const DEFAULT_LOKI_REQUIRE_SCOPE_LABELS = true
+const DEFAULT_MARKET_DATA_MAX_CANDIDATES = 25
+const DEFAULT_MARKET_DATA_MIN_LIQUIDITY_USD = 0
+const DEFAULT_MARKET_DATA_MIN_DEPTH_USD = 0
+const DEFAULT_MARKET_DATA_MAX_SPREAD_BPS = 500
+const DEFAULT_EXECUTION_DEFAULT_VENUE = 'paper'
+const DEFAULT_EXECUTION_MAX_POSITION_USD = 1_000
+const DEFAULT_EXECUTION_REQUIRE_PREFLIGHT = true
+const DEFAULT_EXECUTION_SIGNER_KIND = 'mock'
+const DEFAULT_EXECUTION_STORAGE_KIND = 'memory'
 
 function clampInt(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value))
@@ -79,6 +88,27 @@ const YamlConfigSchema = z
         rulesFile: z.string().trim().optional(),
       })
       .optional(),
+    marketData: z
+      .object({
+        discoveryBaseUrl: z.string().trim().optional(),
+        orderbookBaseUrl: z.string().trim().optional(),
+        maxCandidates: z.number().int().min(1).max(500).optional(),
+        minLiquidityUsd: z.number().nonnegative().optional(),
+        minDepthUsd: z.number().nonnegative().optional(),
+        maxSpreadBps: z.number().nonnegative().optional(),
+        excludedEventTypes: z.array(z.string().trim().min(1)).optional(),
+      })
+      .optional(),
+    execution: z
+      .object({
+        defaultVenue: z.string().trim().min(1).optional(),
+        allowedVenues: z.array(z.string().trim().min(1)).optional(),
+        requirePreflight: z.boolean().optional(),
+        maxPositionUsd: z.number().positive().optional(),
+        signerKind: z.string().trim().min(1).optional(),
+        storageKind: z.string().trim().min(1).optional(),
+      })
+      .optional(),
     limits: z
       .object({
         logCollectionTimeoutMs: z.number().int().positive().optional(),
@@ -127,6 +157,23 @@ const RuntimeConfigSchema = z
       requireScopeLabels: z.boolean(),
       rulesFile: z.string(),
     }),
+    marketData: z.object({
+      discoveryBaseUrl: z.string(),
+      orderbookBaseUrl: z.string(),
+      maxCandidates: z.number().int().min(1).max(500),
+      minLiquidityUsd: z.number().nonnegative(),
+      minDepthUsd: z.number().nonnegative(),
+      maxSpreadBps: z.number().nonnegative(),
+      excludedEventTypes: z.array(z.string().min(1)),
+    }),
+    execution: z.object({
+      defaultVenue: z.string().min(1),
+      allowedVenues: z.array(z.string().min(1)).min(1),
+      requirePreflight: z.boolean(),
+      maxPositionUsd: z.number().positive(),
+      signerKind: z.string().min(1),
+      storageKind: z.string().min(1),
+    }),
     limits: z.object({
       logCollectionTimeoutMs: z.number().int().positive(),
       maxCommandBytes: z.number().int().positive(),
@@ -171,6 +218,8 @@ export function getRuntimeConfig(): RuntimeConfig {
   const debateYaml = yamlConfig.debate ?? {}
   const ollamaYaml = yamlConfig.ollama ?? {}
   const lokiYaml = yamlConfig.loki ?? {}
+  const marketDataYaml = yamlConfig.marketData ?? {}
+  const executionYaml = yamlConfig.execution ?? {}
   const limitsYaml = yamlConfig.limits ?? {}
   const configDir = path.dirname(configFile)
 
@@ -232,6 +281,27 @@ export function getRuntimeConfig(): RuntimeConfig {
     rulesFile,
   }
 
+  const marketData = {
+    discoveryBaseUrl: String(marketDataYaml.discoveryBaseUrl ?? '').trim(),
+    orderbookBaseUrl: String(marketDataYaml.orderbookBaseUrl ?? '').trim(),
+    maxCandidates: marketDataYaml.maxCandidates ?? DEFAULT_MARKET_DATA_MAX_CANDIDATES,
+    minLiquidityUsd: marketDataYaml.minLiquidityUsd ?? DEFAULT_MARKET_DATA_MIN_LIQUIDITY_USD,
+    minDepthUsd: marketDataYaml.minDepthUsd ?? DEFAULT_MARKET_DATA_MIN_DEPTH_USD,
+    maxSpreadBps: marketDataYaml.maxSpreadBps ?? DEFAULT_MARKET_DATA_MAX_SPREAD_BPS,
+    excludedEventTypes: marketDataYaml.excludedEventTypes ?? [],
+  }
+
+  const execution = {
+    defaultVenue: String(executionYaml.defaultVenue ?? DEFAULT_EXECUTION_DEFAULT_VENUE).trim(),
+    allowedVenues: executionYaml.allowedVenues?.map((venue) => venue.trim()).filter(Boolean) ?? [
+      DEFAULT_EXECUTION_DEFAULT_VENUE,
+    ],
+    requirePreflight: executionYaml.requirePreflight ?? DEFAULT_EXECUTION_REQUIRE_PREFLIGHT,
+    maxPositionUsd: executionYaml.maxPositionUsd ?? DEFAULT_EXECUTION_MAX_POSITION_USD,
+    signerKind: String(executionYaml.signerKind ?? DEFAULT_EXECUTION_SIGNER_KIND).trim(),
+    storageKind: String(executionYaml.storageKind ?? DEFAULT_EXECUTION_STORAGE_KIND).trim(),
+  }
+
   cachedRuntimeConfig = RuntimeConfigSchema.parse({
     configFile,
     server,
@@ -240,6 +310,8 @@ export function getRuntimeConfig(): RuntimeConfig {
     debate,
     ollama,
     loki,
+    marketData,
+    execution,
     limits,
   })
   return cachedRuntimeConfig

--- a/src/execution/contracts.test.ts
+++ b/src/execution/contracts.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CandidateRecordSchema,
+  EnrichedCandidateRecordSchema,
+  ExecutionLogRecordSchema,
+  ExecutionRequestSchema,
+  PreflightResultSchema,
+  SignedExecutionRequestSchema,
+} from './contracts.js'
+
+describe('execution foundation contracts', () => {
+  it('parses candidate and enriched candidate records', () => {
+    const candidate = CandidateRecordSchema.parse({
+      marketId: 'mkt-1',
+      eventId: 'evt-1',
+      slug: 'btc-above-100k',
+      question: 'Will BTC close above 100k?',
+      marketType: 'standard',
+      tradable: true,
+      metadataComplete: true,
+    })
+
+    const enriched = EnrichedCandidateRecordSchema.parse({
+      ...candidate,
+      qualificationStatus: 'eligible',
+      qualificationReasons: [],
+      orderbook: {
+        bestBid: 0.48,
+        bestAsk: 0.52,
+        spreadBps: 400,
+        depthUsd: 1200,
+        asOf: '2026-04-19T12:00:00.000Z',
+      },
+      impliedProbability: 0.52,
+    })
+
+    expect(enriched.orderbook.depthUsd).toBe(1200)
+  })
+
+  it('parses preflight results and execution requests', () => {
+    const executionRequest = ExecutionRequestSchema.parse({
+      requestId: 'req-1',
+      intentId: 'intent-1',
+      venue: 'paper',
+      marketId: 'mkt-1',
+      side: 'buy',
+      quantity: 10,
+      executionMode: 'taker',
+      submittedAt: '2026-04-19T12:00:00.000Z',
+    })
+
+    const signedRequest = SignedExecutionRequestSchema.parse({
+      ...executionRequest,
+      signerRef: 'signer-1',
+      signature: 'signed-payload',
+    })
+
+    const preflight = PreflightResultSchema.parse({
+      ok: false,
+      checkedAt: '2026-04-19T12:00:00.000Z',
+      venue: 'paper',
+      checks: [
+        {
+          code: 'spread_above_limit',
+          ok: false,
+          message: 'Spread exceeds configured limit',
+        },
+      ],
+    })
+
+    expect(signedRequest.signature).toBe('signed-payload')
+    expect(preflight.checks[0]?.code).toBe('spread_above_limit')
+  })
+
+  it('parses execution log records and rejects invalid candidate data', () => {
+    const logRecord = ExecutionLogRecordSchema.parse({
+      logId: 'log-1',
+      intentId: 'intent-1',
+      venue: 'paper',
+      status: 'placed',
+      recordedAt: '2026-04-19T12:00:00.000Z',
+      requestId: 'req-1',
+      preflightOk: true,
+    })
+
+    expect(logRecord.status).toBe('placed')
+
+    expect(() =>
+      CandidateRecordSchema.parse({
+        marketId: '',
+        eventId: 'evt-1',
+        slug: 'bad',
+        question: 'bad candidate',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+      })
+    ).toThrow()
+  })
+})

--- a/src/execution/contracts.ts
+++ b/src/execution/contracts.ts
@@ -1,0 +1,131 @@
+import { z } from 'zod'
+import type { AuditEvent, IntentRecord, IntentStatus } from './schema.js'
+
+export const MarketTypeSchema = z.enum(['standard', 'sports', 'election', 'other'])
+
+export const ExecutionModeSchema = z.enum(['taker', 'maker', 'none'])
+
+export const QualificationStatusSchema = z.enum(['eligible', 'filtered', 'blocked'])
+
+export const CandidateDiscoveryQuerySchema = z.object({
+  limit: z.number().int().min(1).max(500).optional(),
+  excludedEventTypes: z.array(MarketTypeSchema).optional(),
+})
+
+export const CandidateRecordSchema = z.object({
+  marketId: z.string().min(1),
+  eventId: z.string().min(1),
+  slug: z.string().min(1),
+  question: z.string().min(1),
+  marketType: MarketTypeSchema,
+  tradable: z.boolean(),
+  metadataComplete: z.boolean(),
+  endDate: z.string().datetime().optional(),
+  tags: z.array(z.string().min(1)).default([]),
+})
+
+export const OrderbookSnapshotSchema = z.object({
+  bestBid: z.number().nonnegative().nullable(),
+  bestAsk: z.number().nonnegative().nullable(),
+  spreadBps: z.number().nonnegative().nullable(),
+  depthUsd: z.number().nonnegative(),
+  asOf: z.string().datetime(),
+})
+
+export const EnrichedCandidateRecordSchema = CandidateRecordSchema.extend({
+  qualificationStatus: QualificationStatusSchema,
+  qualificationReasons: z.array(z.string().min(1)).default([]),
+  orderbook: OrderbookSnapshotSchema,
+  impliedProbability: z.number().min(0).max(1).nullable(),
+})
+
+export const PreflightCheckCodeSchema = z.enum([
+  'candidate_not_tradable',
+  'metadata_incomplete',
+  'spread_above_limit',
+  'depth_below_minimum',
+  'position_above_limit',
+  'venue_not_allowed',
+  'signing_unavailable',
+])
+
+export const PreflightCheckResultSchema = z.object({
+  code: PreflightCheckCodeSchema,
+  ok: z.boolean(),
+  message: z.string().min(1),
+})
+
+export const PreflightResultSchema = z.object({
+  ok: z.boolean(),
+  checkedAt: z.string().datetime(),
+  venue: z.string().min(1),
+  checks: z.array(PreflightCheckResultSchema).min(1),
+})
+
+export const ExecutionRequestSchema = z.object({
+  requestId: z.string().min(1),
+  intentId: z.string().min(1),
+  venue: z.string().min(1),
+  marketId: z.string().min(1),
+  side: z.enum(['buy', 'sell']),
+  quantity: z.number().positive(),
+  limitPrice: z.number().positive().optional(),
+  executionMode: ExecutionModeSchema,
+  submittedAt: z.string().datetime(),
+})
+
+export const SignedExecutionRequestSchema = ExecutionRequestSchema.extend({
+  signerRef: z.string().min(1),
+  signature: z.string().min(1),
+})
+
+export const ExecutionLogRecordSchema = z.object({
+  logId: z.string().min(1),
+  intentId: z.string().min(1),
+  venue: z.string().min(1),
+  status: z.enum(['accepted', 'rejected', 'placed', 'filled', 'cancelled', 'failed']),
+  recordedAt: z.string().datetime(),
+  orderId: z.string().min(1).optional(),
+  requestId: z.string().min(1),
+  preflightOk: z.boolean(),
+  details: z.record(z.string(), z.unknown()).default({}),
+})
+
+export type CandidateDiscoveryQuery = z.infer<typeof CandidateDiscoveryQuerySchema>
+export type CandidateRecord = z.infer<typeof CandidateRecordSchema>
+export type OrderbookSnapshot = z.infer<typeof OrderbookSnapshotSchema>
+export type EnrichedCandidateRecord = z.infer<typeof EnrichedCandidateRecordSchema>
+export type PreflightCheckCode = z.infer<typeof PreflightCheckCodeSchema>
+export type PreflightCheckResult = z.infer<typeof PreflightCheckResultSchema>
+export type PreflightResult = z.infer<typeof PreflightResultSchema>
+export type ExecutionRequest = z.infer<typeof ExecutionRequestSchema>
+export type SignedExecutionRequest = z.infer<typeof SignedExecutionRequestSchema>
+export type ExecutionLogRecord = z.infer<typeof ExecutionLogRecordSchema>
+export type ExecutionMode = z.infer<typeof ExecutionModeSchema>
+
+export type CandidateDiscoveryAdapter = {
+  listCandidates(query: CandidateDiscoveryQuery): Promise<CandidateRecord[]>
+}
+
+export type OrderbookReadAdapter = {
+  getSnapshot(candidate: CandidateRecord): Promise<OrderbookSnapshot>
+}
+
+export type SigningAdapter = {
+  signExecutionRequest(request: ExecutionRequest): Promise<SignedExecutionRequest>
+}
+
+export type ExecutionAdapter = {
+  placeOrder(request: SignedExecutionRequest): Promise<ExecutionLogRecord>
+  cancelOrder(orderId: string, requestId: string): Promise<ExecutionLogRecord>
+}
+
+export type ExecutionRepository = {
+  getIntent(intentId: string): Promise<IntentRecord | null>
+  listIntents(status?: IntentStatus): Promise<IntentRecord[]>
+  saveIntent(intent: IntentRecord): Promise<void>
+  getIntentIdByIdempotencyKey(idempotencyKey: string): Promise<string | null>
+  saveIdempotencyKey(idempotencyKey: string, intentId: string): Promise<void>
+  appendAuditEvent(event: AuditEvent): Promise<void>
+  appendExecutionLog(record: ExecutionLogRecord): Promise<void>
+}

--- a/src/runtimeConfig.test.ts
+++ b/src/runtimeConfig.test.ts
@@ -133,4 +133,21 @@ server:
       },
     })
   })
+
+  it('aligns default allowed venues with a configured default venue', async () => {
+    const configFile = writeConfig(`version: 1
+execution:
+  defaultVenue: sandbox
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(getRuntimeConfig()).toMatchObject({
+      execution: {
+        defaultVenue: 'sandbox',
+        allowedVenues: ['sandbox'],
+      },
+    })
+  })
 })

--- a/src/runtimeConfig.test.ts
+++ b/src/runtimeConfig.test.ts
@@ -52,6 +52,24 @@ loki:
 
 limits:
   maxConcurrency: 7
+marketData:
+  discoveryBaseUrl: http://127.0.0.1:3101
+  orderbookBaseUrl: http://127.0.0.1:3201
+  maxCandidates: 40
+  minLiquidityUsd: 250
+  minDepthUsd: 125
+  maxSpreadBps: 120
+  excludedEventTypes:
+    - sports
+execution:
+  defaultVenue: paper
+  allowedVenues:
+    - paper
+    - sandbox
+  requirePreflight: false
+  maxPositionUsd: 2500
+  signerKind: backend
+  storageKind: sqlite
 `)
 
     vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
@@ -65,7 +83,54 @@ limits:
         maxConcurrent: 3,
         modelAllowlist: ['llama3.1:8b', 'qwen2.5:14b'],
       },
+      marketData: {
+        discoveryBaseUrl: 'http://127.0.0.1:3101',
+        orderbookBaseUrl: 'http://127.0.0.1:3201',
+        maxCandidates: 40,
+        minLiquidityUsd: 250,
+        minDepthUsd: 125,
+        maxSpreadBps: 120,
+        excludedEventTypes: ['sports'],
+      },
+      execution: {
+        defaultVenue: 'paper',
+        allowedVenues: ['paper', 'sandbox'],
+        requirePreflight: false,
+        maxPositionUsd: 2500,
+        signerKind: 'backend',
+        storageKind: 'sqlite',
+      },
       limits: { maxConcurrency: 7 },
+    })
+  })
+
+  it('fills defaults for the new market data and execution sections', async () => {
+    const configFile = writeConfig(`version: 1
+server:
+  port: 3000
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(getRuntimeConfig()).toMatchObject({
+      marketData: {
+        discoveryBaseUrl: '',
+        orderbookBaseUrl: '',
+        maxCandidates: 25,
+        minLiquidityUsd: 0,
+        minDepthUsd: 0,
+        maxSpreadBps: 500,
+        excludedEventTypes: [],
+      },
+      execution: {
+        defaultVenue: 'paper',
+        allowedVenues: ['paper'],
+        requirePreflight: true,
+        maxPositionUsd: 1000,
+        signerKind: 'mock',
+        storageKind: 'memory',
+      },
     })
   })
 })


### PR DESCRIPTION
## Summary
- adds the foundation runtime config sections for downstream market-data and execution work
- introduces shared execution contracts and adapter interfaces for later issues to consume
- adds focused tests for config loading defaults and contract validation

## Issue
- Closes #143

## Ownership boundary
- Config and shared contracts only

## Dependency confirmation
- This is the foundation PR for the next issue wave
- No downstream issue work is included here

## Files touched
- `src/config/runtimeConfig.ts`
- `src/runtimeConfig.test.ts`
- `src/execution/contracts.ts`
- `src/execution/contracts.test.ts`

## Tests run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/runtimeConfig.test.ts src/execution/contracts.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out of scope
- route wiring changes
- execution behavior changes
- persistence implementation
- adapter implementations for discovery, market data, signing, or execution
