### PR TITLE
feat(issue-144): add public discovery adapter for candidate records

### DIFF
--- a/src/execution/discovery.test.ts
+++ b/src/execution/discovery.test.ts
@@ -1,0 +1,305 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function writeConfig(contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-discovery-config-'))
+  const file = path.join(dir, 'blackice.discovery.yaml')
+  writeFileSync(file, contents)
+  tempDirs.push(dir)
+  return file
+}
+
+function createJsonResponse(
+  payload: unknown,
+  init?: { ok?: boolean; status?: number; statusText?: string }
+) {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    json: async () => payload,
+  } as Response
+}
+
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('PublicCandidateDiscoveryAdapter', () => {
+  it('normalizes valid records into candidate records', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  discoveryBaseUrl: https://example.test/discovery
+  maxCandidates: 10
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicCandidateDiscoveryAdapter } = await import('./discovery.js')
+    const fetchImpl = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        markets: [
+          {
+            id: 'market-1',
+            event_id: 'event-1',
+            slug: 'btc-above-100k',
+            question: 'Will BTC close above 100k?',
+            category: 'binary',
+            tradable: true,
+            tags: ['macro'],
+            end_date: '2026-12-31T00:00:00Z',
+          },
+        ],
+      })
+    )
+
+    const adapter = new PublicCandidateDiscoveryAdapter({ fetchImpl })
+    const result = await adapter.listCandidates({})
+
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.test/discovery?limit=10')
+    expect(result).toEqual([
+      {
+        marketId: 'market-1',
+        eventId: 'event-1',
+        slug: 'btc-above-100k',
+        question: 'Will BTC close above 100k?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        endDate: '2026-12-31T00:00:00.000Z',
+        tags: ['macro'],
+      },
+    ])
+  })
+
+  it('filters incomplete and excluded event types', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  discoveryBaseUrl: https://example.test/discovery
+  maxCandidates: 10
+  excludedEventTypes:
+    - sports
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicCandidateDiscoveryAdapter } = await import('./discovery.js')
+    const fetchImpl = vi.fn().mockResolvedValue(
+      createJsonResponse([
+        {
+          id: 'market-1',
+          event_id: 'event-1',
+          slug: 'nba-finals',
+          question: 'Will team A win?',
+          category: 'sports',
+          tradable: true,
+        },
+        {
+          id: 'market-2',
+          event_id: 'event-2',
+          slug: 'missing-question',
+          category: 'standard',
+          tradable: true,
+        },
+        {
+          id: 'market-3',
+          event_id: 'event-3',
+          slug: 'valid-market',
+          question: 'Will CPI fall next month?',
+          category: 'election',
+          tradable: true,
+        },
+      ])
+    )
+
+    const adapter = new PublicCandidateDiscoveryAdapter({ fetchImpl })
+    const result = await adapter.listCandidates({})
+
+    expect(result).toEqual([
+      {
+        marketId: 'market-3',
+        eventId: 'event-3',
+        slug: 'valid-market',
+        question: 'Will CPI fall next month?',
+        marketType: 'election',
+        tradable: true,
+        metadataComplete: true,
+        tags: [],
+      },
+    ])
+  })
+
+  it('clamps the requested limit to the configured maximum and preserves order', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  discoveryBaseUrl: https://example.test/discovery
+  maxCandidates: 2
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicCandidateDiscoveryAdapter } = await import('./discovery.js')
+    const fetchImpl = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        data: [
+          {
+            id: 'market-1',
+            event_id: 'event-1',
+            slug: 'one',
+            question: 'One?',
+            tradable: true,
+          },
+          {
+            id: 'market-2',
+            event_id: 'event-2',
+            slug: 'two',
+            question: 'Two?',
+            tradable: true,
+          },
+          {
+            id: 'market-3',
+            event_id: 'event-3',
+            slug: 'three',
+            question: 'Three?',
+            tradable: true,
+          },
+        ],
+      })
+    )
+
+    const adapter = new PublicCandidateDiscoveryAdapter({ fetchImpl })
+    const result = await adapter.listCandidates({ limit: 25 })
+
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.test/discovery?limit=2')
+    expect(result.map((candidate) => candidate.marketId)).toEqual(['market-1', 'market-2'])
+  })
+
+  it('rejects malformed payloads with a clear adapter error', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  discoveryBaseUrl: https://example.test/discovery
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicCandidateDiscoveryAdapter, DiscoveryAdapterError } = await import(
+      './discovery.js'
+    )
+    const adapter = new PublicCandidateDiscoveryAdapter({
+      fetchImpl: vi.fn().mockResolvedValue(createJsonResponse('bad-payload')),
+    })
+
+    await expect(adapter.listCandidates({})).rejects.toThrow(DiscoveryAdapterError)
+  })
+
+  it('surfaces upstream fetch failures with a clear adapter error', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  discoveryBaseUrl: https://example.test/discovery
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicCandidateDiscoveryAdapter } = await import('./discovery.js')
+    const adapter = new PublicCandidateDiscoveryAdapter({
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(createJsonResponse({}, { ok: false, status: 503, statusText: 'Down' })),
+    })
+
+    await expect(adapter.listCandidates({})).rejects.toThrow(
+      'Discovery request failed with status 503 Down'
+    )
+  })
+
+  it('supports query-level excluded event types and market type mapping edge cases', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  discoveryBaseUrl: https://example.test/discovery
+  maxCandidates: 10
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicCandidateDiscoveryAdapter } = await import('./discovery.js')
+    const adapter = new PublicCandidateDiscoveryAdapter({
+      fetchImpl: vi.fn().mockResolvedValue(
+        createJsonResponse({
+          items: [
+            {
+              id: 'market-1',
+              event_id: 'event-1',
+              slug: 'sports-tag',
+              question: 'Will team A win?',
+              tradable: true,
+              tags: ['sports'],
+            },
+            {
+              id: 'market-2',
+              event_id: 'event-2',
+              slug: 'politics-tag',
+              question: 'Will candidate A win?',
+              tradable: true,
+              tags: ['politics'],
+            },
+            {
+              id: 'market-3',
+              event_id: 'event-3',
+              slug: 'unknown-type',
+              question: 'Will something happen?',
+              tradable: true,
+              category: 'novelty',
+            },
+          ],
+        })
+      ),
+    })
+
+    const result = await adapter.listCandidates({ excludedEventTypes: ['election'] })
+
+    expect(result).toEqual([
+      {
+        marketId: 'market-1',
+        eventId: 'event-1',
+        slug: 'sports-tag',
+        question: 'Will team A win?',
+        marketType: 'sports',
+        tradable: true,
+        metadataComplete: true,
+        tags: ['sports'],
+      },
+      {
+        marketId: 'market-3',
+        eventId: 'event-3',
+        slug: 'unknown-type',
+        question: 'Will something happen?',
+        marketType: 'other',
+        tradable: true,
+        metadataComplete: true,
+        tags: [],
+      },
+    ])
+  })
+
+  it('requires the discovery base URL to be configured', async () => {
+    const configFile = writeConfig(`version: 1
+server:
+  port: 3000
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicCandidateDiscoveryAdapter } = await import('./discovery.js')
+    const adapter = new PublicCandidateDiscoveryAdapter({
+      fetchImpl: vi.fn(),
+    })
+
+    await expect(adapter.listCandidates({})).rejects.toThrow(
+      'marketData.discoveryBaseUrl is not configured'
+    )
+  })
+})

--- a/src/execution/discovery.ts
+++ b/src/execution/discovery.ts
@@ -1,0 +1,305 @@
+import { getRuntimeConfig } from '../config/runtimeConfig.js'
+import {
+  CandidateRecordSchema,
+  type CandidateDiscoveryAdapter,
+  type CandidateDiscoveryQuery,
+  type CandidateRecord,
+  MarketTypeSchema,
+} from './contracts.js'
+
+type DiscoveryFetch = typeof fetch
+
+type DiscoveryAdapterOptions = {
+  fetchImpl?: DiscoveryFetch
+}
+
+type RawDiscoveryRecord = Record<string, unknown>
+type MarketType = 'standard' | 'sports' | 'election' | 'other'
+
+export class DiscoveryAdapterError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DiscoveryAdapterError'
+  }
+}
+
+export class PublicCandidateDiscoveryAdapter implements CandidateDiscoveryAdapter {
+  private readonly fetchImpl: DiscoveryFetch
+
+  constructor(options: DiscoveryAdapterOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? fetch
+  }
+
+  async listCandidates(query: CandidateDiscoveryQuery = {}): Promise<CandidateRecord[]> {
+    const runtimeConfig = getRuntimeConfig()
+    const discoveryBaseUrl = runtimeConfig.marketData.discoveryBaseUrl.trim()
+
+    if (!discoveryBaseUrl) {
+      throw new DiscoveryAdapterError('marketData.discoveryBaseUrl is not configured')
+    }
+
+    const effectiveLimit = resolveEffectiveLimit(
+      query.limit,
+      runtimeConfig.marketData.maxCandidates
+    )
+    const excludedEventTypes = resolveExcludedEventTypes(
+      runtimeConfig.marketData.excludedEventTypes,
+      query.excludedEventTypes ?? []
+    )
+    const endpoint = buildDiscoveryUrl(discoveryBaseUrl, effectiveLimit)
+
+    const response = await this.fetchImpl(endpoint)
+    if (!response.ok) {
+      throw new DiscoveryAdapterError(
+        `Discovery request failed with status ${response.status} ${response.statusText}`
+      )
+    }
+
+    const payload = await response.json()
+    const rawRecords = extractDiscoveryRecords(payload)
+
+    return rawRecords
+      .map((rawRecord) => ({
+        rawRecord,
+        candidate: normalizeDiscoveryRecord(rawRecord),
+      }))
+      .filter(
+        (result): result is { rawRecord: RawDiscoveryRecord; candidate: CandidateRecord } =>
+          result.candidate !== null &&
+          shouldIncludeCandidate(
+            result.candidate,
+            result.rawRecord,
+            excludedEventTypes,
+            runtimeConfig.marketData.minLiquidityUsd
+          )
+      )
+      .map((result) => result.candidate)
+      .slice(0, effectiveLimit)
+  }
+}
+
+function resolveEffectiveLimit(
+  requestedLimit: number | undefined,
+  configuredLimit: number
+): number {
+  if (requestedLimit === undefined) {
+    return configuredLimit
+  }
+
+  return Math.max(1, Math.min(requestedLimit, configuredLimit))
+}
+
+function resolveExcludedEventTypes(configured: string[], requested: MarketType[]): Set<MarketType> {
+  const configuredTypes = configured
+    .map((value) => MarketTypeSchema.safeParse(value))
+    .filter((result) => result.success)
+    .map((result) => result.data)
+
+  return new Set<MarketType>([...configuredTypes, ...requested])
+}
+
+function buildDiscoveryUrl(baseUrl: string, limit: number): string {
+  const url = new URL(baseUrl)
+  url.searchParams.set('limit', String(limit))
+  return url.toString()
+}
+
+function extractDiscoveryRecords(payload: unknown): RawDiscoveryRecord[] {
+  if (Array.isArray(payload)) {
+    return payload.filter(isRecord)
+  }
+
+  if (!isRecord(payload)) {
+    throw new DiscoveryAdapterError('Discovery response must be an array or object payload')
+  }
+
+  for (const key of ['markets', 'events', 'items', 'data']) {
+    const candidate = payload[key]
+    if (Array.isArray(candidate)) {
+      return candidate.filter(isRecord)
+    }
+  }
+
+  throw new DiscoveryAdapterError('Discovery response did not contain a supported record list')
+}
+
+function normalizeDiscoveryRecord(rawRecord: RawDiscoveryRecord): CandidateRecord | null {
+  const marketId = readString(rawRecord, ['marketId', 'market_id', 'id'])
+  const eventId = readString(rawRecord, ['eventId', 'event_id'])
+  const slug = readString(rawRecord, ['slug', 'marketSlug'])
+  const question = readString(rawRecord, ['question', 'title', 'name'])
+
+  if (!marketId || !eventId || !slug || !question) {
+    return null
+  }
+
+  const marketType = inferMarketType(rawRecord)
+  const tradable = inferTradable(rawRecord)
+  const metadataComplete = inferMetadataComplete(rawRecord, {
+    marketId,
+    eventId,
+    slug,
+    question,
+  })
+  const endDate = readIsoDate(rawRecord, ['endDate', 'end_date', 'endTime', 'end_time'])
+  const tags = readTags(rawRecord)
+
+  return CandidateRecordSchema.parse({
+    marketId,
+    eventId,
+    slug,
+    question,
+    marketType,
+    tradable,
+    metadataComplete,
+    endDate,
+    tags,
+  })
+}
+
+function shouldIncludeCandidate(
+  candidate: CandidateRecord,
+  rawRecord: RawDiscoveryRecord,
+  excludedEventTypes: Set<MarketType>,
+  minLiquidityUsd: number
+): boolean {
+  if (!candidate.metadataComplete || !candidate.tradable) {
+    return false
+  }
+
+  if (excludedEventTypes.has(candidate.marketType)) {
+    return false
+  }
+
+  const liquidityUsd = readNumber(rawRecord, ['liquidityUsd', 'liquidity_usd', 'liquidity'])
+  if (typeof liquidityUsd === 'number' && liquidityUsd < minLiquidityUsd) {
+    return false
+  }
+
+  return true
+}
+
+function inferMarketType(rawRecord: RawDiscoveryRecord): MarketType {
+  const explicitType = readString(rawRecord, ['marketType', 'market_type', 'type', 'category'])
+  if (explicitType) {
+    const normalized = explicitType.trim().toLowerCase()
+    if (normalized.includes('sport')) {
+      return 'sports'
+    }
+    if (normalized.includes('election') || normalized.includes('politic')) {
+      return 'election'
+    }
+    if (normalized.includes('standard') || normalized.includes('binary')) {
+      return 'standard'
+    }
+  }
+
+  const tags = readTags(rawRecord).map((tag) => tag.toLowerCase())
+  if (tags.some((tag) => tag.includes('sport'))) {
+    return 'sports'
+  }
+  if (tags.some((tag) => tag.includes('election') || tag.includes('politic'))) {
+    return 'election'
+  }
+
+  return explicitType ? 'other' : 'standard'
+}
+
+function inferTradable(rawRecord: RawDiscoveryRecord): boolean {
+  const booleanCandidates = [
+    readBoolean(rawRecord, ['tradable', 'isTradable']),
+    readBoolean(rawRecord, ['active', 'isActive']),
+    readBoolean(rawRecord, ['closed', 'isClosed']),
+  ]
+
+  if (booleanCandidates[0] !== undefined) {
+    return booleanCandidates[0]
+  }
+  if (booleanCandidates[1] !== undefined) {
+    return booleanCandidates[1]
+  }
+  if (booleanCandidates[2] !== undefined) {
+    return !booleanCandidates[2]
+  }
+
+  return true
+}
+
+function inferMetadataComplete(
+  rawRecord: RawDiscoveryRecord,
+  requiredFields: {
+    marketId: string
+    eventId: string
+    slug: string
+    question: string
+  }
+): boolean {
+  const explicit = readBoolean(rawRecord, ['metadataComplete', 'metadata_complete'])
+  if (explicit !== undefined) {
+    return explicit
+  }
+
+  return Object.values(requiredFields).every((value) => value.trim().length > 0)
+}
+
+function readString(rawRecord: RawDiscoveryRecord, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = rawRecord[key]
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim()
+    }
+  }
+
+  return null
+}
+
+function readBoolean(rawRecord: RawDiscoveryRecord, keys: string[]): boolean | undefined {
+  for (const key of keys) {
+    const value = rawRecord[key]
+    if (typeof value === 'boolean') {
+      return value
+    }
+  }
+
+  return undefined
+}
+
+function readIsoDate(rawRecord: RawDiscoveryRecord, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = rawRecord[key]
+    if (typeof value === 'string' && !Number.isNaN(Date.parse(value))) {
+      return new Date(value).toISOString()
+    }
+  }
+
+  return undefined
+}
+
+function readNumber(rawRecord: RawDiscoveryRecord, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = rawRecord[key]
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
+function readTags(rawRecord: RawDiscoveryRecord): string[] {
+  const tagSources = [rawRecord.tags, rawRecord.categories]
+  for (const tagSource of tagSources) {
+    if (Array.isArray(tagSource)) {
+      return tagSource
+        .filter((value): value is string => typeof value === 'string')
+        .map((value) => value.trim())
+        .filter(Boolean)
+    }
+  }
+
+  return []
+}
+
+function isRecord(value: unknown): value is RawDiscoveryRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}


### PR DESCRIPTION
## Summary
- adds a read-only public discovery adapter for candidate records
- normalizes upstream discovery payloads into shared candidate contracts
- filters incomplete or excluded candidates without leaking raw payload shapes past the adapter boundary
- adds focused unit coverage for normalization, filtering, malformed payloads, limit handling, and fetch failures

## Issue
- Closes #144

## Ownership boundary
- Discovery adapter only

## Dependency confirmation
- Built on merged #143 shared contracts now on `main`
- Does not include orderbook enrichment, preflight, persistence, or route wiring

## Files touched
- `src/execution/discovery.ts`
- `src/execution/discovery.test.ts`

## Tests run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/discovery.test.ts src/runtimeConfig.test.ts src/execution/contracts.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out of scope
- orderbook enrichment
- preflight
- persistence
- HTTP route wiring
- execution behavior
