### PR TITLE
feat(issue-149): add backend signing and credential adapter

### DIFF
--- a/src/execution/signing.test.ts
+++ b/src/execution/signing.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ExecutionRequest } from './contracts.js'
+import {
+  BackendSigningAdapter,
+  EnvironmentSigningCredentialsProvider,
+  MockSigningAdapter,
+  SigningAdapterError,
+  canonicalizeExecutionRequest,
+  createSigningAdapter,
+} from './signing.js'
+
+const tempDirs: string[] = []
+
+function writeConfig(contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-signing-config-'))
+  const file = path.join(dir, 'blackice.test.yaml')
+  writeFileSync(file, contents)
+  tempDirs.push(dir)
+  return file
+}
+
+function buildExecutionRequest(overrides: Partial<ExecutionRequest> = {}): ExecutionRequest {
+  return {
+    requestId: 'req-149',
+    intentId: 'intent-149',
+    venue: 'paper',
+    marketId: 'market-149',
+    side: 'buy',
+    quantity: 12,
+    limitPrice: 0.47,
+    executionMode: 'taker',
+    submittedAt: '2026-04-21T16:00:00.000Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('signing adapters', () => {
+  it('signs execution requests with backend credentials without leaking secrets', async () => {
+    const adapter = new BackendSigningAdapter({
+      credentialsProvider: {
+        async getCredentials() {
+          return {
+            signerRef: 'backend-signer-1',
+            secret: 'super-secret-key',
+          }
+        },
+      },
+    })
+
+    const signed = await adapter.signExecutionRequest(buildExecutionRequest())
+
+    expect(signed).toMatchObject({
+      signerRef: 'backend-signer-1',
+      requestId: 'req-149',
+      intentId: 'intent-149',
+    })
+    expect(signed.signature).toMatch(/^[a-f0-9]{64}$/)
+    expect(JSON.stringify(signed)).not.toContain('super-secret-key')
+  })
+
+  it('creates deterministic mock signatures from the canonical request', async () => {
+    const adapter = new MockSigningAdapter()
+    const request = buildExecutionRequest()
+
+    const first = await adapter.signExecutionRequest(request)
+    const second = await adapter.signExecutionRequest(request)
+
+    expect(first).toEqual(second)
+    expect(first.signerRef).toBe('mock:paper')
+    expect(first.signature).toMatch(/^mock:[a-f0-9]{64}$/)
+  })
+
+  it('reads backend credentials from environment variables', async () => {
+    vi.stubEnv('BLACKICE_EXECUTION_SIGNER_REF', 'env-signer')
+    vi.stubEnv('BLACKICE_EXECUTION_SIGNING_SECRET', 'env-secret')
+    const provider = new EnvironmentSigningCredentialsProvider()
+
+    await expect(provider.getCredentials()).resolves.toEqual({
+      signerRef: 'env-signer',
+      secret: 'env-secret',
+    })
+  })
+
+  it('fails clearly when backend signing credentials are missing', async () => {
+    const provider = new EnvironmentSigningCredentialsProvider()
+
+    await expect(provider.getCredentials()).rejects.toThrow(SigningAdapterError)
+    await expect(provider.getCredentials()).rejects.toThrow(
+      'BLACKICE_EXECUTION_SIGNER_REF is required for backend signing'
+    )
+  })
+
+  it('creates a backend adapter from runtime config when signerKind=backend', async () => {
+    const configFile = writeConfig(`version: 1
+execution:
+  signerKind: backend
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    vi.stubEnv('BLACKICE_EXECUTION_SIGNER_REF', 'runtime-signer')
+    vi.stubEnv('BLACKICE_EXECUTION_SIGNING_SECRET', 'runtime-secret')
+
+    const { createSigningAdapter: createFromModule } = await import('./signing.js')
+    const adapter = createFromModule()
+    const signed = await adapter.signExecutionRequest(buildExecutionRequest())
+
+    expect(signed.signerRef).toBe('runtime-signer')
+    expect(signed.signature).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('rejects unsupported signer kinds', () => {
+    expect(() => createSigningAdapter({ signerKind: 'remote-kms' })).toThrow(
+      'Unsupported execution.signerKind: remote-kms'
+    )
+  })
+
+  it('canonicalizes requests with explicit field ordering', () => {
+    const canonical = canonicalizeExecutionRequest(
+      buildExecutionRequest({
+        limitPrice: undefined,
+      })
+    )
+
+    expect(canonical).toBe(
+      JSON.stringify({
+        requestId: 'req-149',
+        intentId: 'intent-149',
+        venue: 'paper',
+        marketId: 'market-149',
+        side: 'buy',
+        quantity: 12,
+        limitPrice: null,
+        executionMode: 'taker',
+        submittedAt: '2026-04-21T16:00:00.000Z',
+      })
+    )
+  })
+})

--- a/src/execution/signing.ts
+++ b/src/execution/signing.ts
@@ -1,0 +1,136 @@
+import { createHash, createHmac } from 'node:crypto'
+import { getRuntimeConfig } from '../config/runtimeConfig.js'
+import {
+  ExecutionRequestSchema,
+  type ExecutionRequest,
+  type SignedExecutionRequest,
+  SignedExecutionRequestSchema,
+  type SigningAdapter,
+} from './contracts.js'
+
+const SIGNER_REF_ENV = 'BLACKICE_EXECUTION_SIGNER_REF'
+const SIGNING_SECRET_ENV = 'BLACKICE_EXECUTION_SIGNING_SECRET'
+
+export type SigningCredentials = {
+  signerRef: string
+  secret: string
+}
+
+export type SigningCredentialsProvider = {
+  getCredentials(): Promise<SigningCredentials>
+}
+
+export type SignatureCalculator = {
+  signCanonicalRequest(
+    canonicalRequest: string,
+    credentials: SigningCredentials
+  ): Promise<string> | string
+}
+
+type CreateSigningAdapterOptions = {
+  signerKind?: string
+  credentialsProvider?: SigningCredentialsProvider
+  signatureCalculator?: SignatureCalculator
+}
+
+export class SigningAdapterError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SigningAdapterError'
+  }
+}
+
+export class EnvironmentSigningCredentialsProvider implements SigningCredentialsProvider {
+  async getCredentials(): Promise<SigningCredentials> {
+    const signerRef = readRequiredEnv(SIGNER_REF_ENV)
+    const secret = readRequiredEnv(SIGNING_SECRET_ENV)
+
+    return {
+      signerRef,
+      secret,
+    }
+  }
+}
+
+export class HmacSha256SignatureCalculator implements SignatureCalculator {
+  signCanonicalRequest(canonicalRequest: string, credentials: SigningCredentials): string {
+    return createHmac('sha256', credentials.secret).update(canonicalRequest).digest('hex')
+  }
+}
+
+export class BackendSigningAdapter implements SigningAdapter {
+  private readonly credentialsProvider: SigningCredentialsProvider
+  private readonly signatureCalculator: SignatureCalculator
+
+  constructor(options: CreateSigningAdapterOptions = {}) {
+    this.credentialsProvider =
+      options.credentialsProvider ?? new EnvironmentSigningCredentialsProvider()
+    this.signatureCalculator = options.signatureCalculator ?? new HmacSha256SignatureCalculator()
+  }
+
+  async signExecutionRequest(request: ExecutionRequest): Promise<SignedExecutionRequest> {
+    const normalizedRequest = ExecutionRequestSchema.parse(request)
+    const credentials = await this.credentialsProvider.getCredentials()
+    const canonicalRequest = canonicalizeExecutionRequest(normalizedRequest)
+    const signature = await this.signatureCalculator.signCanonicalRequest(
+      canonicalRequest,
+      credentials
+    )
+
+    return SignedExecutionRequestSchema.parse({
+      ...normalizedRequest,
+      signerRef: credentials.signerRef,
+      signature,
+    })
+  }
+}
+
+export class MockSigningAdapter implements SigningAdapter {
+  async signExecutionRequest(request: ExecutionRequest): Promise<SignedExecutionRequest> {
+    const normalizedRequest = ExecutionRequestSchema.parse(request)
+    const canonicalRequest = canonicalizeExecutionRequest(normalizedRequest)
+
+    return SignedExecutionRequestSchema.parse({
+      ...normalizedRequest,
+      signerRef: `mock:${normalizedRequest.venue}`,
+      signature: `mock:${createHash('sha256').update(canonicalRequest).digest('hex')}`,
+    })
+  }
+}
+
+export function createSigningAdapter(options: CreateSigningAdapterOptions = {}): SigningAdapter {
+  const signerKind = (options.signerKind ?? getRuntimeConfig().execution.signerKind).trim()
+
+  switch (signerKind) {
+    case 'backend':
+      return new BackendSigningAdapter(options)
+    case 'mock':
+      return new MockSigningAdapter()
+    default:
+      throw new SigningAdapterError(`Unsupported execution.signerKind: ${signerKind}`)
+  }
+}
+
+export function canonicalizeExecutionRequest(request: ExecutionRequest): string {
+  const normalizedRequest = ExecutionRequestSchema.parse(request)
+
+  return JSON.stringify({
+    requestId: normalizedRequest.requestId,
+    intentId: normalizedRequest.intentId,
+    venue: normalizedRequest.venue,
+    marketId: normalizedRequest.marketId,
+    side: normalizedRequest.side,
+    quantity: normalizedRequest.quantity,
+    limitPrice: normalizedRequest.limitPrice ?? null,
+    executionMode: normalizedRequest.executionMode,
+    submittedAt: normalizedRequest.submittedAt,
+  })
+}
+
+function readRequiredEnv(name: string): string {
+  const value = String(process.env[name] ?? '').trim()
+  if (!value) {
+    throw new SigningAdapterError(`${name} is required for backend signing`)
+  }
+  return value
+}


### PR DESCRIPTION
Closes #149

## Summary
- add a dedicated signing adapter module behind the shared execution contracts
- support config-driven signer selection via `execution.signerKind`
- keep backend credential handling internal to the adapter boundary and out of request/response contracts

## Ownership boundary
- signing/auth adapter modules only
- no route changes
- no repository redesign
- no order placement lifecycle work
- no discovery/orderbook changes

## Dependency confirmation
- built on the merged shared execution contracts from #143

## Files touched
- `src/execution/signing.ts`
- `src/execution/signing.test.ts`

## Tests run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/signing.test.ts src/execution/contracts.test.ts src/runtimeConfig.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out of scope
- route wiring
- repository storage changes
- execution lifecycle placement/cancel logic
- discovery and orderbook adapters