### PR TITLE
feat(issue-148): replace in-memory execution state with a durable repository

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -36,6 +36,7 @@ const DEFAULT_EXECUTION_MAX_POSITION_USD = 1_000
 const DEFAULT_EXECUTION_REQUIRE_PREFLIGHT = true
 const DEFAULT_EXECUTION_SIGNER_KIND = 'mock'
 const DEFAULT_EXECUTION_STORAGE_KIND = 'memory'
+const DEFAULT_EXECUTION_STORAGE_PATH = ''
 
 function clampInt(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value))
@@ -107,6 +108,7 @@ const YamlConfigSchema = z
         maxPositionUsd: z.number().positive().optional(),
         signerKind: z.string().trim().min(1).optional(),
         storageKind: z.string().trim().min(1).optional(),
+        storagePath: z.string().trim().optional(),
       })
       .optional(),
     limits: z
@@ -173,6 +175,7 @@ const RuntimeConfigSchema = z
       maxPositionUsd: z.number().positive(),
       signerKind: z.string().min(1),
       storageKind: z.string().min(1),
+      storagePath: z.string(),
     }),
     limits: z.object({
       logCollectionTimeoutMs: z.number().int().positive(),
@@ -302,6 +305,7 @@ export function getRuntimeConfig(): RuntimeConfig {
     maxPositionUsd: executionYaml.maxPositionUsd ?? DEFAULT_EXECUTION_MAX_POSITION_USD,
     signerKind: String(executionYaml.signerKind ?? DEFAULT_EXECUTION_SIGNER_KIND).trim(),
     storageKind: String(executionYaml.storageKind ?? DEFAULT_EXECUTION_STORAGE_KIND).trim(),
+    storagePath: String(executionYaml.storagePath ?? DEFAULT_EXECUTION_STORAGE_PATH).trim(),
   }
 
   cachedRuntimeConfig = RuntimeConfigSchema.parse({

--- a/src/execution/contracts.ts
+++ b/src/execution/contracts.ts
@@ -121,11 +121,11 @@ export type ExecutionAdapter = {
 }
 
 export type ExecutionRepository = {
-  getIntent(intentId: string): Promise<IntentRecord | null>
-  listIntents(status?: IntentStatus): Promise<IntentRecord[]>
-  saveIntent(intent: IntentRecord): Promise<void>
-  getIntentIdByIdempotencyKey(idempotencyKey: string): Promise<string | null>
-  saveIdempotencyKey(idempotencyKey: string, intentId: string): Promise<void>
-  appendAuditEvent(event: AuditEvent): Promise<void>
-  appendExecutionLog(record: ExecutionLogRecord): Promise<void>
+  getIntent(intentId: string): IntentRecord | null
+  listIntents(status?: IntentStatus): IntentRecord[]
+  saveIntent(intent: IntentRecord): void
+  getIntentIdByIdempotencyKey(idempotencyKey: string): string | null
+  saveIdempotencyKey(idempotencyKey: string, intentId: string): void
+  appendAuditEvent(event: AuditEvent): void
+  appendExecutionLog(record: ExecutionLogRecord): void
 }

--- a/src/execution/repository.test.ts
+++ b/src/execution/repository.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { IntentRecord } from './schema.js'
+import { FileExecutionRepository, InMemoryExecutionRepository } from './repository.js'
+
+const tempDirs: string[] = []
+
+function makeTempPath(filename: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-exec-repo-'))
+  tempDirs.push(dir)
+  return path.join(dir, filename)
+}
+
+function buildIntent(overrides: Partial<IntentRecord> = {}): IntentRecord {
+  return {
+    intentId: 'intent-1',
+    idempotencyKey: 'idem-1',
+    accountId: 'acct-1',
+    market: 'BTC-USD',
+    venue: 'paper',
+    side: 'buy',
+    quantity: 1,
+    notionalUsd: 1000,
+    ttlSeconds: 300,
+    status: 'submitted',
+    createdAt: '2026-04-21T00:00:00.000Z',
+    updatedAt: '2026-04-21T00:00:00.000Z',
+    expiresAt: '2026-04-21T00:05:00.000Z',
+    metadata: {},
+    orders: [],
+    auditTrail: [],
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('execution repositories', () => {
+  it('stores and retrieves intents in memory', () => {
+    const repository = new InMemoryExecutionRepository()
+    const intent = buildIntent()
+
+    repository.saveIntent(intent)
+    repository.saveIdempotencyKey(intent.idempotencyKey, intent.intentId)
+
+    expect(repository.getIntent(intent.intentId)).toMatchObject(intent)
+    expect(repository.getIntentIdByIdempotencyKey(intent.idempotencyKey)).toBe(intent.intentId)
+  })
+
+  it('persists intents to disk across repository instances', () => {
+    const storagePath = makeTempPath('execution-state.json')
+    const firstRepository = new FileExecutionRepository(storagePath)
+    const intent = buildIntent()
+
+    firstRepository.saveIntent(intent)
+    firstRepository.saveIdempotencyKey(intent.idempotencyKey, intent.intentId)
+
+    const secondRepository = new FileExecutionRepository(storagePath)
+    expect(secondRepository.getIntent(intent.intentId)).toMatchObject(intent)
+    expect(secondRepository.getIntentIdByIdempotencyKey(intent.idempotencyKey)).toBe(
+      intent.intentId
+    )
+
+    const persisted = JSON.parse(readFileSync(storagePath, 'utf8'))
+    expect(persisted.idempotencyKeys[intent.idempotencyKey]).toBe(intent.intentId)
+  })
+})

--- a/src/execution/repository.ts
+++ b/src/execution/repository.ts
@@ -1,0 +1,176 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { ExecutionLogRecord, ExecutionRepository } from './contracts.js'
+import type { IntentRecord, IntentStatus } from './schema.js'
+import { AuditEventSchema, IntentRecordSchema } from './schema.js'
+
+type StoredExecutionState = {
+  intents: Record<string, IntentRecord>
+  idempotencyKeys: Record<string, string>
+  executionLogs: ExecutionLogRecord[]
+}
+
+const EMPTY_STATE: StoredExecutionState = {
+  intents: {},
+  idempotencyKeys: {},
+  executionLogs: [],
+}
+
+function cloneIntent(intent: IntentRecord): IntentRecord {
+  return IntentRecordSchema.parse(structuredClone(intent))
+}
+
+function cloneState(state: StoredExecutionState): StoredExecutionState {
+  return {
+    intents: Object.fromEntries(
+      Object.entries(state.intents).map(([intentId, intent]) => [intentId, cloneIntent(intent)])
+    ),
+    idempotencyKeys: { ...state.idempotencyKeys },
+    executionLogs: structuredClone(state.executionLogs),
+  }
+}
+
+function parseState(raw: string): StoredExecutionState {
+  const parsed = JSON.parse(raw) as Partial<StoredExecutionState>
+  const intents = Object.fromEntries(
+    Object.entries(parsed.intents ?? {}).map(([intentId, intent]) => [
+      intentId,
+      IntentRecordSchema.parse(intent),
+    ])
+  )
+
+  return {
+    intents,
+    idempotencyKeys: { ...(parsed.idempotencyKeys ?? {}) },
+    executionLogs: structuredClone(parsed.executionLogs ?? []),
+  }
+}
+
+export class InMemoryExecutionRepository implements ExecutionRepository {
+  private state: StoredExecutionState
+
+  constructor(seedState: StoredExecutionState = EMPTY_STATE) {
+    this.state = cloneState(seedState)
+  }
+
+  getIntent(intentId: string): IntentRecord | null {
+    const intent = this.state.intents[intentId]
+    return intent ? cloneIntent(intent) : null
+  }
+
+  listIntents(status?: IntentStatus): IntentRecord[] {
+    const intents = Object.values(this.state.intents).map(cloneIntent)
+    return status ? intents.filter((intent) => intent.status === status) : intents
+  }
+
+  saveIntent(intent: IntentRecord): void {
+    this.state.intents[intent.intentId] = cloneIntent(intent)
+  }
+
+  getIntentIdByIdempotencyKey(idempotencyKey: string): string | null {
+    return this.state.idempotencyKeys[idempotencyKey] ?? null
+  }
+
+  saveIdempotencyKey(idempotencyKey: string, intentId: string): void {
+    this.state.idempotencyKeys[idempotencyKey] = intentId
+  }
+
+  appendAuditEvent(event: IntentRecord['auditTrail'][number]): void {
+    const parsedEvent = AuditEventSchema.parse(event)
+    const intent = this.state.intents[parsedEvent.intentId]
+    if (!intent) {
+      return
+    }
+
+    const nextIntent = cloneIntent(intent)
+    nextIntent.auditTrail.push(parsedEvent)
+    this.state.intents[parsedEvent.intentId] = nextIntent
+  }
+
+  appendExecutionLog(record: ExecutionLogRecord): void {
+    this.state.executionLogs.push(structuredClone(record))
+  }
+}
+
+export class FileExecutionRepository implements ExecutionRepository {
+  constructor(private readonly filePath: string) {
+    ensureRepositoryFile(filePath)
+  }
+
+  getIntent(intentId: string): IntentRecord | null {
+    const state = this.readState()
+    const intent = state.intents[intentId]
+    return intent ? cloneIntent(intent) : null
+  }
+
+  listIntents(status?: IntentStatus): IntentRecord[] {
+    const intents = Object.values(this.readState().intents).map(cloneIntent)
+    return status ? intents.filter((intent) => intent.status === status) : intents
+  }
+
+  saveIntent(intent: IntentRecord): void {
+    const state = this.readState()
+    state.intents[intent.intentId] = cloneIntent(intent)
+    this.writeState(state)
+  }
+
+  getIntentIdByIdempotencyKey(idempotencyKey: string): string | null {
+    return this.readState().idempotencyKeys[idempotencyKey] ?? null
+  }
+
+  saveIdempotencyKey(idempotencyKey: string, intentId: string): void {
+    const state = this.readState()
+    state.idempotencyKeys[idempotencyKey] = intentId
+    this.writeState(state)
+  }
+
+  appendAuditEvent(event: IntentRecord['auditTrail'][number]): void {
+    const parsedEvent = AuditEventSchema.parse(event)
+    const state = this.readState()
+    const intent = state.intents[parsedEvent.intentId]
+    if (!intent) {
+      return
+    }
+
+    const nextIntent = cloneIntent(intent)
+    nextIntent.auditTrail.push(parsedEvent)
+    state.intents[parsedEvent.intentId] = nextIntent
+    this.writeState(state)
+  }
+
+  appendExecutionLog(record: ExecutionLogRecord): void {
+    const state = this.readState()
+    state.executionLogs.push(structuredClone(record))
+    this.writeState(state)
+  }
+
+  private readState(): StoredExecutionState {
+    return parseState(readFileSync(this.filePath, 'utf8'))
+  }
+
+  private writeState(state: StoredExecutionState): void {
+    writeFileSync(this.filePath, JSON.stringify(state, null, 2))
+  }
+}
+
+export function createExecutionRepository(options: {
+  storageKind: string
+  storagePath?: string
+}): ExecutionRepository {
+  if (options.storageKind === 'memory') {
+    return new InMemoryExecutionRepository()
+  }
+
+  if (!options.storagePath) {
+    throw new Error(`execution.storagePath is required for storageKind=${options.storageKind}`)
+  }
+
+  return new FileExecutionRepository(options.storagePath)
+}
+
+function ensureRepositoryFile(filePath: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, JSON.stringify(EMPTY_STATE, null, 2))
+  }
+}

--- a/src/execution/service.test.ts
+++ b/src/execution/service.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { FileExecutionRepository } from './repository.js'
 import { ExecutionPolicyError, ExecutionService, IntentStateError } from './service.js'
 
 function buildService() {
@@ -25,6 +29,14 @@ const validIntent = {
   notionalUsd: 10_000,
   ttlSeconds: 300,
 }
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
 
 function createDeferredPromise<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
@@ -209,5 +221,31 @@ describe('ExecutionService', () => {
 
     signerGate.resolve({ signerRef: 'local-signer:test' })
     await expect(executionPromise).resolves.toMatchObject({ status: 'executed' })
+  })
+
+  it('reloads intents from a durable repository across service instances', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'blackice-service-repo-'))
+    tempDirs.push(dir)
+    const storagePath = path.join(dir, 'execution-state.json')
+
+    const firstRepository = new FileExecutionRepository(storagePath)
+    const firstService = new ExecutionService({
+      repository: firstRepository,
+      now: () => new Date('2026-04-18T12:00:00.000Z'),
+    })
+    const submitted = firstService.submitIntent(validIntent, 'req-1')
+
+    const secondRepository = new FileExecutionRepository(storagePath)
+    const secondService = new ExecutionService({
+      repository: secondRepository,
+      now: () => new Date('2026-04-18T12:00:01.000Z'),
+    })
+
+    expect(secondService.getIntent(submitted.intent.intentId)).toMatchObject({
+      intentId: submitted.intent.intentId,
+      idempotencyKey: validIntent.idempotencyKey,
+      status: 'submitted',
+    })
+    expect(secondService.listIntents()).toHaveLength(1)
   })
 })

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -1,4 +1,7 @@
 import { randomUUID } from 'node:crypto'
+import { getRuntimeConfig } from '../config/runtimeConfig.js'
+import type { ExecutionRepository } from './contracts.js'
+import { createExecutionRepository } from './repository.js'
 import {
   type AuditEvent,
   AuditEventSchema,
@@ -54,6 +57,7 @@ type ExecutionServiceOptions = {
   policy?: ExecutionPolicySnapshot
   signer?: Signer
   venueExecutor?: VenueExecutor
+  repository?: ExecutionRepository
   now?: () => Date
 }
 
@@ -82,17 +86,22 @@ class InMemoryVenueExecutor implements VenueExecutor {
 }
 
 export class ExecutionService {
-  private readonly intents = new Map<string, IntentRecord>()
-  private readonly idempotencyKeys = new Map<string, string>()
   private readonly policy: ExecutionPolicySnapshot
   private readonly signer: Signer
   private readonly venueExecutor: VenueExecutor
+  private readonly repository: ExecutionRepository
   private readonly now: () => Date
 
   constructor(options: ExecutionServiceOptions = {}) {
     this.policy = options.policy ?? DEFAULT_POLICY
     this.signer = options.signer ?? new InMemorySigner()
     this.venueExecutor = options.venueExecutor ?? new InMemoryVenueExecutor()
+    this.repository =
+      options.repository ??
+      createExecutionRepository({
+        storageKind: getRuntimeConfig().execution.storageKind,
+        storagePath: getRuntimeConfig().execution.storagePath,
+      })
     this.now = options.now ?? (() => new Date())
   }
 
@@ -101,12 +110,11 @@ export class ExecutionService {
   }
 
   listIntents(status?: IntentRecord['status']): IntentRecord[] {
-    const intents = Array.from(this.intents.values())
-    return status ? intents.filter((intent) => intent.status === status) : intents
+    return this.repository.listIntents(status)
   }
 
   getIntent(intentId: string): IntentRecord {
-    const intent = this.intents.get(intentId)
+    const intent = this.repository.getIntent(intentId)
     if (!intent) {
       throw new IntentNotFoundError(intentId)
     }
@@ -117,7 +125,7 @@ export class ExecutionService {
     input: SubmitIntentRequest,
     requestId: string
   ): { created: boolean; intent: IntentRecord } {
-    const existingIntentId = this.idempotencyKeys.get(input.idempotencyKey)
+    const existingIntentId = this.repository.getIntentIdByIdempotencyKey(input.idempotencyKey)
     if (existingIntentId) {
       const existingIntent = this.getIntent(existingIntentId)
       if (!this.matchesExistingIntent(existingIntent, input)) {
@@ -135,7 +143,7 @@ export class ExecutionService {
 
     const nowIso = this.now().toISOString()
     const intentId = input.intentId ?? randomUUID()
-    if (this.intents.has(intentId)) {
+    if (this.repository.getIntent(intentId)) {
       throw new IntentStateError(`Intent already exists: ${intentId}`)
     }
 
@@ -166,8 +174,8 @@ export class ExecutionService {
       notionalUsd: input.notionalUsd,
     })
 
-    this.intents.set(intent.intentId, intent)
-    this.idempotencyKeys.set(input.idempotencyKey, intent.intentId)
+    this.repository.saveIntent(intent)
+    this.repository.saveIdempotencyKey(input.idempotencyKey, intent.intentId)
 
     return { created: true, intent }
   }
@@ -188,6 +196,7 @@ export class ExecutionService {
     intent.confirmedAt = nowIso
     intent.updatedAt = nowIso
     this.appendAuditEvent(intent, 'intent_confirmed', requestId, {})
+    this.repository.saveIntent(intent)
     return intent
   }
 
@@ -209,17 +218,20 @@ export class ExecutionService {
     const requestedAt = this.now().toISOString()
     intent.status = 'execution_pending'
     intent.updatedAt = requestedAt
+    this.repository.saveIntent(intent)
     this.appendAuditEvent(intent, 'signing_requested', requestId, {})
 
     try {
       const signed = await this.signer.signIntent(intent)
       intent.signerRef = signed.signerRef
+      this.repository.saveIntent(intent)
       this.appendAuditEvent(intent, 'signing_succeeded', requestId, {
         signerRef: signed.signerRef,
       })
     } catch (error) {
       intent.status = 'confirmed'
       intent.updatedAt = this.now().toISOString()
+      this.repository.saveIntent(intent)
       this.appendAuditEvent(intent, 'signing_failed', requestId, {
         error: error instanceof Error ? error.message : String(error),
       })
@@ -246,11 +258,13 @@ export class ExecutionService {
       })
 
       intent.orders.push(order)
+      this.repository.saveIntent(intent)
 
       if (execution.status === 'filled') {
         intent.status = 'executed'
         intent.executedAt = nowIso
         intent.updatedAt = nowIso
+        this.repository.saveIntent(intent)
         this.appendAuditEvent(intent, 'execution_succeeded', requestId, {
           externalOrderId: execution.externalOrderId,
           orderStatus: execution.status,
@@ -261,6 +275,7 @@ export class ExecutionService {
       if (execution.status === 'pending' || execution.status === 'placed') {
         intent.status = 'execution_pending'
         intent.updatedAt = nowIso
+        this.repository.saveIntent(intent)
         this.appendAuditEvent(intent, 'execution_pending', requestId, {
           externalOrderId: execution.externalOrderId,
           orderStatus: execution.status,
@@ -270,6 +285,7 @@ export class ExecutionService {
 
       intent.status = 'confirmed'
       intent.updatedAt = nowIso
+      this.repository.saveIntent(intent)
       this.appendAuditEvent(
         intent,
         execution.status === 'cancelled' ? 'execution_cancelled' : 'execution_failed',
@@ -284,6 +300,7 @@ export class ExecutionService {
       const nowIso = this.now().toISOString()
       intent.status = 'confirmed'
       intent.updatedAt = nowIso
+      this.repository.saveIntent(intent)
       this.appendAuditEvent(intent, 'execution_failed', requestId, {
         error: error instanceof Error ? error.message : String(error),
       })
@@ -307,6 +324,7 @@ export class ExecutionService {
     intent.cancelledAt = nowIso
     intent.updatedAt = nowIso
     this.appendAuditEvent(intent, 'intent_cancelled', requestId, {})
+    this.repository.saveIntent(intent)
     return intent
   }
 
@@ -332,7 +350,8 @@ export class ExecutionService {
 
     const windowStart = this.now()
     windowStart.setUTCHours(0, 0, 0, 0)
-    const todayNotional = Array.from(this.intents.values())
+    const todayNotional = this.repository
+      .listIntents()
       .filter((intent) => Date.parse(intent.createdAt) >= windowStart.getTime())
       .reduce((total, intent) => total + intent.notionalUsd, 0)
 
@@ -350,16 +369,17 @@ export class ExecutionService {
     requestId: string,
     details: Record<string, unknown>
   ): void {
-    intent.auditTrail.push(
-      AuditEventSchema.parse({
-        eventId: randomUUID(),
-        intentId: intent.intentId,
-        type,
-        timestamp: this.now().toISOString(),
-        requestId,
-        details,
-      })
-    )
+    const event = AuditEventSchema.parse({
+      eventId: randomUUID(),
+      intentId: intent.intentId,
+      type,
+      timestamp: this.now().toISOString(),
+      requestId,
+      details,
+    })
+    intent.auditTrail.push(event)
+    this.repository.appendAuditEvent(event)
+    this.repository.saveIntent(intent)
   }
 
   private matchesExistingIntent(intent: IntentRecord, input: SubmitIntentRequest): boolean {

--- a/src/runtimeConfig.test.ts
+++ b/src/runtimeConfig.test.ts
@@ -70,6 +70,7 @@ execution:
   maxPositionUsd: 2500
   signerKind: backend
   storageKind: sqlite
+  storagePath: ./.tmp/execution-state.json
 `)
 
     vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
@@ -99,6 +100,7 @@ execution:
         maxPositionUsd: 2500,
         signerKind: 'backend',
         storageKind: 'sqlite',
+        storagePath: './.tmp/execution-state.json',
       },
       limits: { maxConcurrency: 7 },
     })
@@ -130,6 +132,7 @@ server:
         maxPositionUsd: 1000,
         signerKind: 'mock',
         storageKind: 'memory',
+        storagePath: '',
       },
     })
   })
@@ -147,6 +150,7 @@ execution:
       execution: {
         defaultVenue: 'sandbox',
         allowedVenues: ['sandbox'],
+        storagePath: '',
       },
     })
   })


### PR DESCRIPTION
## Summary
- adds a repository abstraction for execution state and a durable file-backed repository implementation
- refactors `ExecutionService` to depend on repository storage instead of owning in-memory maps directly
- extends execution runtime config with `storagePath` and adds restart-safe persistence tests

## Issue
- Closes #148

## Ownership boundary
- Repository abstraction, storage implementation, and execution service persistence wiring only

## Dependency confirmation
- Built on merged #143 contracts and the current main execution service shape
- Does not include route changes, signing logic, discovery/orderbook work, or execution lifecycle redesign

## Files touched
- `src/execution/contracts.ts`
- `src/execution/repository.ts`
- `src/execution/repository.test.ts`
- `src/execution/service.ts`
- `src/execution/service.test.ts`
- `src/config/runtimeConfig.ts`
- `src/runtimeConfig.test.ts`

## Tests run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/repository.test.ts src/execution/service.test.ts src/runtimeConfig.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out of scope
- route wiring changes
- signing/auth implementation
- discovery/orderbook adapters
- preflight rules
- execution adapter lifecycle changes
