### PR TITLE
feat(issue-145): add public orderbook enrichment adapter

### DIFF
--- a/src/execution/orderbook.test.ts
+++ b/src/execution/orderbook.test.ts
@@ -1,0 +1,261 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function writeConfig(contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-orderbook-config-'))
+  const file = path.join(dir, 'blackice.orderbook.yaml')
+  writeFileSync(file, contents)
+  tempDirs.push(dir)
+  return file
+}
+
+function createJsonResponse(
+  payload: unknown,
+  init?: { ok?: boolean; status?: number; statusText?: string }
+) {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    json: async () => payload,
+  } as Response
+}
+
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('PublicOrderbookReadAdapter', () => {
+  it('normalizes best bid, best ask, spread, depth, and timestamp', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  orderbookBaseUrl: https://example.test/orderbook
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicOrderbookReadAdapter } = await import('./orderbook.js')
+    const fetchImpl = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        orderbook: {
+          bids: [
+            { price: '0.42', size: '100' },
+            { price: '0.41', size: 80 },
+          ],
+          asks: [
+            { price: 0.47, size: 110 },
+            { price: 0.49, size: 50 },
+          ],
+          updated_at: '2026-04-21T18:30:00Z',
+        },
+      })
+    )
+
+    const adapter = new PublicOrderbookReadAdapter({ fetchImpl })
+    const result = await adapter.getSnapshot({
+      marketId: 'market-1',
+      eventId: 'event-1',
+      slug: 'btc-above-100k',
+      question: 'Will BTC close above 100k?',
+      marketType: 'standard',
+      tradable: true,
+      metadataComplete: true,
+      tags: [],
+    })
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://example.test/orderbook?marketId=market-1&eventId=event-1'
+    )
+    expect(result).toEqual({
+      bestBid: 0.42,
+      bestAsk: 0.47,
+      spreadBps: 1063.83,
+      depthUsd: 151,
+      asOf: '2026-04-21T18:30:00.000Z',
+    })
+  })
+
+  it('returns null best prices and zero depth for an empty book', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  orderbookBaseUrl: https://example.test/orderbook
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicOrderbookReadAdapter } = await import('./orderbook.js')
+    const adapter = new PublicOrderbookReadAdapter({
+      fetchImpl: vi.fn().mockResolvedValue(createJsonResponse({ bids: [], asks: [] })),
+      now: () => new Date('2026-04-21T20:00:00.000Z'),
+    })
+
+    await expect(
+      adapter.getSnapshot({
+        marketId: 'market-2',
+        eventId: 'event-2',
+        slug: 'empty',
+        question: 'Empty?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        tags: [],
+      })
+    ).resolves.toEqual({
+      bestBid: null,
+      bestAsk: null,
+      spreadBps: null,
+      depthUsd: 0,
+      asOf: '2026-04-21T20:00:00.000Z',
+    })
+  })
+
+  it('handles missing sides by preserving the available best price and null spread', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  orderbookBaseUrl: https://example.test/orderbook
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicOrderbookReadAdapter } = await import('./orderbook.js')
+    const adapter = new PublicOrderbookReadAdapter({
+      fetchImpl: vi.fn().mockResolvedValue(
+        createJsonResponse({
+          bids: [[0.44, 150]],
+        })
+      ),
+      now: () => new Date('2026-04-21T20:05:00.000Z'),
+    })
+
+    await expect(
+      adapter.getSnapshot({
+        marketId: 'market-3',
+        eventId: 'event-3',
+        slug: 'bid-only',
+        question: 'Bid only?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        tags: [],
+      })
+    ).resolves.toEqual({
+      bestBid: 0.44,
+      bestAsk: null,
+      spreadBps: null,
+      depthUsd: 66,
+      asOf: '2026-04-21T20:05:00.000Z',
+    })
+  })
+
+  it('ignores malformed levels with missing numeric values but rejects malformed side containers', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  orderbookBaseUrl: https://example.test/orderbook
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicOrderbookReadAdapter, OrderbookAdapterError } = await import('./orderbook.js')
+    const adapter = new PublicOrderbookReadAdapter({
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(
+          createJsonResponse({
+            bids: [
+              { price: 'oops', size: 100 },
+              { price: 0.4, size: 50 },
+            ],
+            asks: [
+              { price: 0.45, size: 20 },
+              { price: 0.5, size: 0 },
+            ],
+          })
+        )
+        .mockResolvedValueOnce(createJsonResponse({ bids: 'bad-side', asks: [] })),
+      now: () => new Date('2026-04-21T20:10:00.000Z'),
+    })
+
+    await expect(
+      adapter.getSnapshot({
+        marketId: 'market-4',
+        eventId: 'event-4',
+        slug: 'mixed-levels',
+        question: 'Mixed levels?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        tags: [],
+      })
+    ).resolves.toEqual({
+      bestBid: 0.4,
+      bestAsk: 0.45,
+      spreadBps: 1111.11,
+      depthUsd: 29,
+      asOf: '2026-04-21T20:10:00.000Z',
+    })
+
+    await expect(
+      adapter.getSnapshot({
+        marketId: 'market-5',
+        eventId: 'event-5',
+        slug: 'bad-side',
+        question: 'Bad side?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        tags: [],
+      })
+    ).rejects.toThrow(OrderbookAdapterError)
+  })
+
+  it('rejects malformed payloads and surfaces upstream failures clearly', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  orderbookBaseUrl: https://example.test/orderbook
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { PublicOrderbookReadAdapter, OrderbookAdapterError } = await import('./orderbook.js')
+    const adapter = new PublicOrderbookReadAdapter({
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(createJsonResponse('bad-payload'))
+        .mockResolvedValueOnce(
+          createJsonResponse({}, { ok: false, status: 502, statusText: 'Bad Gateway' })
+        ),
+    })
+
+    await expect(
+      adapter.getSnapshot({
+        marketId: 'market-6',
+        eventId: 'event-6',
+        slug: 'bad-payload',
+        question: 'Bad payload?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        tags: [],
+      })
+    ).rejects.toThrow(OrderbookAdapterError)
+
+    await expect(
+      adapter.getSnapshot({
+        marketId: 'market-7',
+        eventId: 'event-7',
+        slug: 'upstream-fail',
+        question: 'Upstream fail?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        tags: [],
+      })
+    ).rejects.toThrow('Orderbook request failed with status 502 Bad Gateway')
+  })
+})

--- a/src/execution/orderbook.ts
+++ b/src/execution/orderbook.ts
@@ -1,0 +1,235 @@
+import { getRuntimeConfig } from '../config/runtimeConfig.js'
+import {
+  OrderbookSnapshotSchema,
+  type CandidateRecord,
+  type OrderbookReadAdapter,
+  type OrderbookSnapshot,
+} from './contracts.js'
+
+type OrderbookFetch = typeof fetch
+type Clock = () => Date
+
+type OrderbookAdapterOptions = {
+  fetchImpl?: OrderbookFetch
+  now?: Clock
+}
+
+type RawOrderbookPayload = Record<string, unknown>
+type RawPriceLevel = {
+  price: number
+  size: number
+}
+
+export class OrderbookAdapterError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'OrderbookAdapterError'
+  }
+}
+
+export class PublicOrderbookReadAdapter implements OrderbookReadAdapter {
+  private readonly fetchImpl: OrderbookFetch
+  private readonly now: Clock
+
+  constructor(options: OrderbookAdapterOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? fetch
+    this.now = options.now ?? (() => new Date())
+  }
+
+  async getSnapshot(candidate: CandidateRecord): Promise<OrderbookSnapshot> {
+    const runtimeConfig = getRuntimeConfig()
+    const orderbookBaseUrl = runtimeConfig.marketData.orderbookBaseUrl.trim()
+
+    if (!orderbookBaseUrl) {
+      throw new OrderbookAdapterError('marketData.orderbookBaseUrl is not configured')
+    }
+
+    const response = await this.fetchImpl(buildOrderbookUrl(orderbookBaseUrl, candidate))
+    if (!response.ok) {
+      throw new OrderbookAdapterError(
+        `Orderbook request failed with status ${response.status} ${response.statusText}`
+      )
+    }
+
+    const payload = await response.json()
+    const orderbookPayload = extractOrderbookPayload(payload)
+    const timestamp = resolveSnapshotTimestamp(orderbookPayload, this.now)
+    const bids = parseSideLevels(orderbookPayload, 'bids')
+    const asks = parseSideLevels(orderbookPayload, 'asks')
+
+    return buildSnapshot(bids, asks, timestamp)
+  }
+}
+
+function buildOrderbookUrl(baseUrl: string, candidate: CandidateRecord): string {
+  const url = new URL(baseUrl)
+  url.searchParams.set('marketId', candidate.marketId)
+  url.searchParams.set('eventId', candidate.eventId)
+  return url.toString()
+}
+
+function extractOrderbookPayload(payload: unknown): RawOrderbookPayload {
+  if (!isRecord(payload)) {
+    throw new OrderbookAdapterError('Orderbook response must be an object payload')
+  }
+
+  const nested = payload.orderbook
+  if (isRecord(nested)) {
+    return nested
+  }
+
+  if ('bids' in payload || 'asks' in payload) {
+    return payload
+  }
+
+  throw new OrderbookAdapterError('Orderbook response did not contain bid/ask data')
+}
+
+function parseSideLevels(payload: RawOrderbookPayload, side: 'bids' | 'asks'): RawPriceLevel[] {
+  const rawLevels = payload[side]
+  if (rawLevels === undefined) {
+    return []
+  }
+
+  if (!Array.isArray(rawLevels)) {
+    throw new OrderbookAdapterError(`Orderbook ${side} must be an array`)
+  }
+
+  return rawLevels
+    .map((level) => parsePriceLevel(level, side))
+    .filter((level): level is RawPriceLevel => level !== null)
+}
+
+function parsePriceLevel(level: unknown, side: 'bids' | 'asks'): RawPriceLevel | null {
+  if (Array.isArray(level)) {
+    const [priceValue, sizeValue] = level
+    return normalizePriceLevel(priceValue, sizeValue, side)
+  }
+
+  if (isRecord(level)) {
+    return normalizePriceLevel(
+      firstDefined(level.price, level.p),
+      firstDefined(level.size, level.quantity, level.amount, level.shares, level.q),
+      side
+    )
+  }
+
+  throw new OrderbookAdapterError(`Orderbook ${side} level must be an array or object`)
+}
+
+function normalizePriceLevel(
+  priceValue: unknown,
+  sizeValue: unknown,
+  side: 'bids' | 'asks'
+): RawPriceLevel | null {
+  const price = parseFiniteNumber(priceValue)
+  const size = parseFiniteNumber(sizeValue)
+
+  if (price === null || size === null) {
+    return null
+  }
+
+  if (price < 0 || size < 0) {
+    throw new OrderbookAdapterError(`Orderbook ${side} level values must be non-negative`)
+  }
+
+  if (size === 0) {
+    return null
+  }
+
+  return { price, size }
+}
+
+function buildSnapshot(
+  bids: RawPriceLevel[],
+  asks: RawPriceLevel[],
+  asOf: string
+): OrderbookSnapshot {
+  const bestBid = selectBestPrice(bids, 'bids')
+  const bestAsk = selectBestPrice(asks, 'asks')
+  const spreadBps =
+    bestBid === null || bestAsk === null || bestAsk === 0
+      ? null
+      : roundToBasisPoints(((bestAsk - bestBid) / bestAsk) * 10_000)
+  const depthUsd = roundToCents(computeDepthUsd(bids) + computeDepthUsd(asks))
+
+  return OrderbookSnapshotSchema.parse({
+    bestBid,
+    bestAsk,
+    spreadBps,
+    depthUsd,
+    asOf,
+  })
+}
+
+function selectBestPrice(levels: RawPriceLevel[], side: 'bids' | 'asks'): number | null {
+  if (levels.length === 0) {
+    return null
+  }
+
+  const prices = levels.map((level) => level.price)
+  const bestPrice = side === 'bids' ? Math.max(...prices) : Math.min(...prices)
+  return roundToPrice(bestPrice)
+}
+
+function computeDepthUsd(levels: RawPriceLevel[]): number {
+  return levels.reduce((sum, level) => sum + level.price * level.size, 0)
+}
+
+function resolveSnapshotTimestamp(payload: RawOrderbookPayload, now: Clock): string {
+  for (const key of ['asOf', 'as_of', 'timestamp', 'updatedAt', 'updated_at']) {
+    const rawValue = payload[key]
+    const timestamp = parseTimestamp(rawValue)
+    if (timestamp) {
+      return timestamp
+    }
+  }
+
+  return now().toISOString()
+}
+
+function parseTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return null
+  }
+
+  const timestamp = new Date(value)
+  if (Number.isNaN(timestamp.getTime())) {
+    return null
+  }
+
+  return timestamp.toISOString()
+}
+
+function parseFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+function firstDefined<T>(...values: (T | undefined)[]): T | undefined {
+  return values.find((value) => value !== undefined)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function roundToPrice(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000
+}
+
+function roundToCents(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+function roundToBasisPoints(value: number): number {
+  return Math.round(value * 100) / 100
+}


### PR DESCRIPTION
Closes #145

## Summary
- add a read-only public orderbook adapter under `src/execution/`
- normalize best bid, best ask, spread, depth, and timestamp into the shared orderbook snapshot contract
- cover empty books, missing sides, malformed payloads, malformed levels, and upstream failures with focused unit tests

## Ownership boundary
- issue #145 only: orderbook enrichment adapter
- no route wiring, persistence, signing, or execution service changes

## Dependency confirmation
- built on merged shared contracts from #143 and candidate shape from #144

## Files touched
- `src/execution/orderbook.ts`
- `src/execution/orderbook.test.ts`

## Tests run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/orderbook.test.ts src/execution/contracts.test.ts src/runtimeConfig.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out of scope
- route integration
- execution service changes
- persistence changes
- signing changes
- preflight logic
- candidate enrichment orchestration