### PR TITLE
feat(issue-146): build candidate enrichment pipeline

### DIFF
--- a/src/execution/contracts.ts
+++ b/src/execution/contracts.ts
@@ -111,6 +111,10 @@ export type OrderbookReadAdapter = {
   getSnapshot(candidate: CandidateRecord): Promise<OrderbookSnapshot>
 }
 
+export type CandidateEnrichmentAdapter = {
+  listEnrichedCandidates(query: CandidateDiscoveryQuery): Promise<EnrichedCandidateRecord[]>
+}
+
 export type SigningAdapter = {
   signExecutionRequest(request: ExecutionRequest): Promise<SignedExecutionRequest>
 }

--- a/src/execution/enrichment.test.ts
+++ b/src/execution/enrichment.test.ts
@@ -1,0 +1,194 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  CandidateDiscoveryAdapter,
+  CandidateRecord,
+  OrderbookReadAdapter,
+  OrderbookSnapshot,
+} from './contracts.js'
+
+const tempDirs: string[] = []
+
+function writeConfig(contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-enrichment-config-'))
+  const file = path.join(dir, 'blackice.enrichment.yaml')
+  writeFileSync(file, contents)
+  tempDirs.push(dir)
+  return file
+}
+
+function buildCandidate(overrides: Partial<CandidateRecord> = {}): CandidateRecord {
+  return {
+    marketId: 'market-1',
+    eventId: 'event-1',
+    slug: 'btc-above-100k',
+    question: 'Will BTC close above 100k?',
+    marketType: 'standard',
+    tradable: true,
+    metadataComplete: true,
+    tags: [],
+    ...overrides,
+  }
+}
+
+function buildSnapshot(overrides: Partial<OrderbookSnapshot> = {}): OrderbookSnapshot {
+  return {
+    bestBid: 0.46,
+    bestAsk: 0.5,
+    spreadBps: 800,
+    depthUsd: 2_500,
+    asOf: '2026-04-22T01:45:00.000Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('CandidateEnrichmentPipeline', () => {
+  it('builds eligible enriched candidates and preserves discovery order', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 1000
+  maxSpreadBps: 1000
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { CandidateEnrichmentPipeline } = await import('./enrichment.js')
+    const discoveryAdapter: CandidateDiscoveryAdapter = {
+      listCandidates: vi.fn().mockResolvedValue([
+        buildCandidate({
+          marketId: 'market-1',
+          eventId: 'event-1',
+          slug: 'one',
+          question: 'One?',
+        }),
+        buildCandidate({
+          marketId: 'market-2',
+          eventId: 'event-2',
+          slug: 'two',
+          question: 'Two?',
+        }),
+      ]),
+    }
+    const orderbookAdapter: OrderbookReadAdapter = {
+      getSnapshot: vi
+        .fn()
+        .mockResolvedValueOnce(
+          buildSnapshot({
+            bestBid: 0.4,
+            bestAsk: 0.5,
+            spreadBps: 2000,
+            depthUsd: 1500,
+          })
+        )
+        .mockResolvedValueOnce(
+          buildSnapshot({
+            bestBid: 0.48,
+            bestAsk: 0.5,
+            spreadBps: 400,
+            depthUsd: 2000,
+          })
+        ),
+    }
+
+    const pipeline = new CandidateEnrichmentPipeline({ discoveryAdapter, orderbookAdapter })
+    const enrichedCandidates = await pipeline.listEnrichedCandidates({ limit: 2 })
+
+    expect(discoveryAdapter.listCandidates).toHaveBeenCalledWith({ limit: 2 })
+    expect(enrichedCandidates.map((candidate) => candidate.marketId)).toEqual([
+      'market-1',
+      'market-2',
+    ])
+    expect(enrichedCandidates[0]).toMatchObject({
+      qualificationStatus: 'filtered',
+      qualificationReasons: ['spread_above_limit'],
+      impliedProbability: 0.45,
+    })
+    expect(enrichedCandidates[1]).toMatchObject({
+      qualificationStatus: 'eligible',
+      qualificationReasons: [],
+      impliedProbability: 0.49,
+    })
+  })
+
+  it('marks candidates as blocked when tradability or metadata is missing', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 0
+  maxSpreadBps: 1000
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { CandidateEnrichmentPipeline } = await import('./enrichment.js')
+    const discoveryAdapter: CandidateDiscoveryAdapter = {
+      listCandidates: vi.fn().mockResolvedValue([
+        buildCandidate({
+          marketId: 'market-3',
+          eventId: 'event-3',
+          slug: 'blocked',
+          question: 'Blocked?',
+          tradable: false,
+          metadataComplete: false,
+        }),
+      ]),
+    }
+    const orderbookAdapter: OrderbookReadAdapter = {
+      getSnapshot: vi.fn().mockResolvedValue(buildSnapshot()),
+    }
+
+    const pipeline = new CandidateEnrichmentPipeline({ discoveryAdapter, orderbookAdapter })
+    const [enrichedCandidate] = await pipeline.listEnrichedCandidates({})
+
+    expect(enrichedCandidate).toMatchObject({
+      qualificationStatus: 'blocked',
+      qualificationReasons: ['candidate_not_tradable', 'metadata_incomplete'],
+      impliedProbability: 0.48,
+    })
+  })
+
+  it('flags low-depth books and returns null implied probability for out-of-range prices', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 500
+  maxSpreadBps: 1000
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { CandidateEnrichmentPipeline } = await import('./enrichment.js')
+    const discoveryAdapter: CandidateDiscoveryAdapter = {
+      listCandidates: vi
+        .fn()
+        .mockResolvedValue([buildCandidate({ marketId: 'market-4', eventId: 'event-4' })]),
+    }
+    const orderbookAdapter: OrderbookReadAdapter = {
+      getSnapshot: vi.fn().mockResolvedValue(
+        buildSnapshot({
+          bestBid: null,
+          bestAsk: 1.25,
+          spreadBps: null,
+          depthUsd: 125,
+        })
+      ),
+    }
+
+    const pipeline = new CandidateEnrichmentPipeline({ discoveryAdapter, orderbookAdapter })
+    const [enrichedCandidate] = await pipeline.listEnrichedCandidates({})
+
+    expect(enrichedCandidate).toMatchObject({
+      qualificationStatus: 'filtered',
+      qualificationReasons: ['depth_below_minimum'],
+      impliedProbability: null,
+    })
+  })
+})

--- a/src/execution/enrichment.ts
+++ b/src/execution/enrichment.ts
@@ -1,0 +1,146 @@
+import { getRuntimeConfig } from '../config/runtimeConfig.js'
+import {
+  EnrichedCandidateRecordSchema,
+  type CandidateDiscoveryAdapter,
+  type CandidateDiscoveryQuery,
+  type CandidateEnrichmentAdapter,
+  type CandidateRecord,
+  type EnrichedCandidateRecord,
+  type OrderbookReadAdapter,
+  type OrderbookSnapshot,
+} from './contracts.js'
+
+type CandidateEnrichmentPipelineOptions = {
+  discoveryAdapter: CandidateDiscoveryAdapter
+  orderbookAdapter: OrderbookReadAdapter
+}
+
+type QualificationConfig = {
+  minDepthUsd: number
+  maxSpreadBps: number
+}
+
+const BLOCKING_REASON_CODES = ['candidate_not_tradable', 'metadata_incomplete'] as const
+const FILTERING_REASON_CODES = ['spread_above_limit', 'depth_below_minimum'] as const
+
+export class CandidateEnrichmentPipeline implements CandidateEnrichmentAdapter {
+  constructor(private readonly options: CandidateEnrichmentPipelineOptions) {}
+
+  async listEnrichedCandidates(
+    query: CandidateDiscoveryQuery = {}
+  ): Promise<EnrichedCandidateRecord[]> {
+    const candidates = await this.options.discoveryAdapter.listCandidates(query)
+    const qualificationConfig = resolveQualificationConfig()
+
+    return Promise.all(
+      candidates.map((candidate) => this.enrichCandidate(candidate, qualificationConfig))
+    )
+  }
+
+  private async enrichCandidate(
+    candidate: CandidateRecord,
+    qualificationConfig: QualificationConfig
+  ): Promise<EnrichedCandidateRecord> {
+    const orderbook = await this.options.orderbookAdapter.getSnapshot(candidate)
+    const qualificationReasons = buildQualificationReasons(
+      candidate,
+      orderbook,
+      qualificationConfig
+    )
+    const qualificationStatus = determineQualificationStatus(qualificationReasons)
+
+    return EnrichedCandidateRecordSchema.parse({
+      ...candidate,
+      qualificationStatus,
+      qualificationReasons,
+      orderbook,
+      impliedProbability: resolveImpliedProbability(orderbook),
+    })
+  }
+}
+
+function buildQualificationReasons(
+  candidate: CandidateRecord,
+  orderbook: OrderbookSnapshot,
+  qualificationConfig: QualificationConfig
+): string[] {
+  const reasons: string[] = []
+
+  if (!candidate.tradable) {
+    reasons.push('candidate_not_tradable')
+  }
+
+  if (!candidate.metadataComplete) {
+    reasons.push('metadata_incomplete')
+  }
+
+  if (orderbook.spreadBps !== null && orderbook.spreadBps > qualificationConfig.maxSpreadBps) {
+    reasons.push('spread_above_limit')
+  }
+
+  if (orderbook.depthUsd < qualificationConfig.minDepthUsd) {
+    reasons.push('depth_below_minimum')
+  }
+
+  return reasons
+}
+
+function determineQualificationStatus(
+  qualificationReasons: string[]
+): EnrichedCandidateRecord['qualificationStatus'] {
+  if (qualificationReasons.some(isBlockingReason)) {
+    return 'blocked'
+  }
+
+  if (qualificationReasons.some(isFilteringReason)) {
+    return 'filtered'
+  }
+
+  return 'eligible'
+}
+
+function isBlockingReason(reason: string): boolean {
+  return BLOCKING_REASON_CODES.some((code) => code === reason)
+}
+
+function isFilteringReason(reason: string): boolean {
+  return FILTERING_REASON_CODES.some((code) => code === reason)
+}
+
+function resolveImpliedProbability(orderbook: OrderbookSnapshot): number | null {
+  const midpointProbability = resolveMidpointProbability(orderbook)
+  if (midpointProbability !== null) {
+    return midpointProbability
+  }
+
+  return normalizeProbability(orderbook.bestAsk ?? orderbook.bestBid)
+}
+
+function resolveMidpointProbability(orderbook: OrderbookSnapshot): number | null {
+  if (orderbook.bestBid === null || orderbook.bestAsk === null) {
+    return null
+  }
+
+  return normalizeProbability((orderbook.bestBid + orderbook.bestAsk) / 2)
+}
+
+function normalizeProbability(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  if (value < 0 || value > 1) {
+    return null
+  }
+
+  return Math.round(value * 1_000_000) / 1_000_000
+}
+
+function resolveQualificationConfig(): QualificationConfig {
+  const runtimeConfig = getRuntimeConfig()
+
+  return {
+    minDepthUsd: runtimeConfig.marketData.minDepthUsd,
+    maxSpreadBps: runtimeConfig.marketData.maxSpreadBps,
+  }
+}


### PR DESCRIPTION
Closes #146

## Summary
- add a candidate enrichment pipeline that composes the merged discovery and orderbook adapters
- derive deterministic qualification status/reasons from runtime-config spread and depth thresholds
- add focused pipeline tests for eligible, filtered, and blocked candidate outputs

## Ownership Boundary
- candidate enrichment orchestration only
- consumes merged discovery and orderbook contracts from `#144` and `#145`

## Files Touched
- `src/execution/contracts.ts`
- `src/execution/enrichment.ts`
- `src/execution/enrichment.test.ts`

## Tests Run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/enrichment.test.ts src/execution/contracts.test.ts src/execution/discovery.test.ts src/execution/orderbook.test.ts src/runtimeConfig.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out Of Scope
- preflight validation
- route wiring
- execution lifecycle logic
- persistence changes
