### PR TITLE
feat(issue-150): add execution adapter and normalized order lifecycle tracking

### DIFF
--- a/src/execution/executionAdapter.test.ts
+++ b/src/execution/executionAdapter.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildExecutionRequestFromIntent,
+  buildOrderRecordFromExecutionLog,
+  mapExecutionLogToAuditEventType,
+  mapExecutionLogToIntentStatus,
+  mapExecutionLogToOrderStatus,
+  PaperExecutionAdapter,
+} from './executionAdapter.js'
+import type { ExecutionLogRecord } from './contracts.js'
+import type { IntentRecord } from './schema.js'
+
+const baseIntent: IntentRecord = {
+  intentId: 'intent-1',
+  idempotencyKey: 'idem-1',
+  accountId: 'acct-1',
+  market: 'BTC-USD',
+  venue: 'paper',
+  side: 'buy',
+  quantity: 2,
+  limitPrice: 0.51,
+  notionalUsd: 102,
+  ttlSeconds: 300,
+  status: 'confirmed',
+  createdAt: '2026-04-22T00:00:00.000Z',
+  updatedAt: '2026-04-22T00:00:00.000Z',
+  confirmedAt: '2026-04-22T00:00:00.000Z',
+  expiresAt: '2026-04-22T00:05:00.000Z',
+  metadata: {},
+  orders: [],
+  auditTrail: [],
+}
+
+describe('executionAdapter', () => {
+  it('builds execution requests from intents with a stable default execution mode', () => {
+    const request = buildExecutionRequestFromIntent(
+      {
+        ...baseIntent,
+        metadata: {
+          executionMode: 'maker',
+        },
+      },
+      'req-1',
+      '2026-04-22T00:01:00.000Z'
+    )
+
+    expect(request).toMatchObject({
+      requestId: 'req-1',
+      intentId: baseIntent.intentId,
+      marketId: baseIntent.market,
+      executionMode: 'maker',
+    })
+
+    const fallbackRequest = buildExecutionRequestFromIntent(
+      {
+        ...baseIntent,
+        metadata: {
+          executionMode: 'bad-mode',
+        },
+      },
+      'req-2',
+      '2026-04-22T00:02:00.000Z'
+    )
+
+    expect(fallbackRequest.executionMode).toBe('taker')
+  })
+
+  it.each([
+    ['accepted', 'pending', 'execution_pending', 'execution_pending'],
+    ['placed', 'placed', 'execution_pending', 'execution_pending'],
+    ['filled', 'filled', 'executed', 'execution_succeeded'],
+    ['cancelled', 'cancelled', 'confirmed', 'execution_cancelled'],
+    ['failed', 'failed', 'confirmed', 'execution_failed'],
+    ['rejected', 'failed', 'confirmed', 'execution_failed'],
+  ] as const)(
+    'maps %s execution logs into normalized lifecycle records',
+    (logStatus, orderStatus, intentStatus, auditType) => {
+      expect(mapExecutionLogToOrderStatus(logStatus)).toBe(orderStatus)
+      expect(mapExecutionLogToIntentStatus(logStatus)).toBe(intentStatus)
+      expect(mapExecutionLogToAuditEventType(logStatus)).toBe(auditType)
+    }
+  )
+
+  it('builds order records with venue ids and failure reasons from execution logs', () => {
+    const log: ExecutionLogRecord = {
+      logId: 'log-1',
+      intentId: baseIntent.intentId,
+      venue: baseIntent.venue,
+      status: 'failed',
+      recordedAt: '2026-04-22T00:03:00.000Z',
+      orderId: 'venue-order-1',
+      requestId: 'req-3',
+      preflightOk: true,
+      details: {
+        reason: 'insufficient depth',
+      },
+    }
+
+    const order = buildOrderRecordFromExecutionLog({
+      intent: baseIntent,
+      executionLog: log,
+    })
+
+    expect(order).toMatchObject({
+      status: 'failed',
+      externalOrderId: 'venue-order-1',
+      failureReason: 'insufficient depth',
+    })
+  })
+
+  it('provides a paper adapter with deterministic filled and cancelled logs', async () => {
+    const adapter = new PaperExecutionAdapter()
+
+    const placed = await adapter.placeOrder({
+      ...buildExecutionRequestFromIntent(baseIntent, 'req-4', '2026-04-22T00:04:00.000Z'),
+      signerRef: 'mock:paper',
+      signature: 'sig-1',
+    })
+    const cancelled = await adapter.cancelOrder('venue-order-2', 'req-5')
+
+    expect(placed.status).toBe('filled')
+    expect(placed.orderId).toBe('paper-req-4')
+    expect(cancelled.status).toBe('cancelled')
+    expect(cancelled.orderId).toBe('venue-order-2')
+  })
+})

--- a/src/execution/executionAdapter.ts
+++ b/src/execution/executionAdapter.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto'
+import { getRuntimeConfig } from '../config/runtimeConfig.js'
+import {
+  type ExecutionAdapter,
+  type ExecutionLogRecord,
+  ExecutionLogRecordSchema,
+  ExecutionModeSchema,
+  type ExecutionRequest,
+  ExecutionRequestSchema,
+  type SignedExecutionRequest,
+  SignedExecutionRequestSchema,
+} from './contracts.js'
+import type { AuditEvent, IntentRecord, OrderRecord } from './schema.js'
+import { OrderRecordSchema } from './schema.js'
+
+const DEFAULT_EXECUTION_MODE = 'taker'
+
+export class ExecutionAdapterError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ExecutionAdapterError'
+  }
+}
+
+export class PaperExecutionAdapter implements ExecutionAdapter {
+  async placeOrder(request: SignedExecutionRequest): Promise<ExecutionLogRecord> {
+    const normalizedRequest = SignedExecutionRequestSchema.parse(request)
+    const nowIso = new Date().toISOString()
+
+    return ExecutionLogRecordSchema.parse({
+      logId: randomUUID(),
+      intentId: normalizedRequest.intentId,
+      venue: normalizedRequest.venue,
+      status: 'filled',
+      recordedAt: nowIso,
+      orderId: `paper-${normalizedRequest.requestId}`,
+      requestId: normalizedRequest.requestId,
+      preflightOk: true,
+      details: {
+        executionMode: normalizedRequest.executionMode,
+      },
+    })
+  }
+
+  async cancelOrder(orderId: string, requestId: string): Promise<ExecutionLogRecord> {
+    return ExecutionLogRecordSchema.parse({
+      logId: randomUUID(),
+      intentId: orderId,
+      venue: 'paper',
+      status: 'cancelled',
+      recordedAt: new Date().toISOString(),
+      orderId,
+      requestId,
+      preflightOk: true,
+      details: {},
+    })
+  }
+}
+
+export function createExecutionAdapter(options: { venue?: string } = {}): ExecutionAdapter {
+  const venue = (options.venue ?? getRuntimeConfig().execution.defaultVenue).trim()
+
+  switch (venue) {
+    case 'paper':
+      return new PaperExecutionAdapter()
+    default:
+      throw new ExecutionAdapterError(`Unsupported execution.defaultVenue: ${venue}`)
+  }
+}
+
+export function buildExecutionRequestFromIntent(
+  intent: IntentRecord,
+  requestId: string,
+  submittedAt: string
+): ExecutionRequest {
+  const executionMode = resolveExecutionMode(intent)
+
+  return ExecutionRequestSchema.parse({
+    requestId,
+    intentId: intent.intentId,
+    venue: intent.venue,
+    marketId: intent.market,
+    side: intent.side,
+    quantity: intent.quantity,
+    limitPrice: intent.limitPrice,
+    executionMode,
+    submittedAt,
+  })
+}
+
+export function mapExecutionLogToOrderStatus(
+  status: ExecutionLogRecord['status']
+): OrderRecord['status'] {
+  switch (status) {
+    case 'accepted':
+      return 'pending'
+    case 'placed':
+      return 'placed'
+    case 'filled':
+      return 'filled'
+    case 'cancelled':
+      return 'cancelled'
+    case 'failed':
+    case 'rejected':
+      return 'failed'
+  }
+}
+
+export function mapExecutionLogToIntentStatus(
+  status: ExecutionLogRecord['status']
+): IntentRecord['status'] {
+  switch (status) {
+    case 'accepted':
+    case 'placed':
+      return 'execution_pending'
+    case 'filled':
+      return 'executed'
+    case 'cancelled':
+    case 'failed':
+    case 'rejected':
+      return 'confirmed'
+  }
+}
+
+export function mapExecutionLogToAuditEventType(
+  status: ExecutionLogRecord['status']
+): AuditEvent['type'] {
+  switch (status) {
+    case 'accepted':
+    case 'placed':
+      return 'execution_pending'
+    case 'filled':
+      return 'execution_succeeded'
+    case 'cancelled':
+      return 'execution_cancelled'
+    case 'failed':
+    case 'rejected':
+      return 'execution_failed'
+  }
+}
+
+export function buildOrderRecordFromExecutionLog(input: {
+  intent: IntentRecord
+  executionLog: ExecutionLogRecord
+  recordedAt?: string
+}): OrderRecord {
+  const recordedAt = input.recordedAt ?? input.executionLog.recordedAt
+  const failureReason = extractFailureReason(input.executionLog)
+
+  return OrderRecordSchema.parse({
+    orderId: randomUUID(),
+    venue: input.intent.venue,
+    market: input.intent.market,
+    side: input.intent.side,
+    quantity: input.intent.quantity,
+    limitPrice: input.intent.limitPrice,
+    notionalUsd: input.intent.notionalUsd,
+    status: mapExecutionLogToOrderStatus(input.executionLog.status),
+    createdAt: recordedAt,
+    updatedAt: recordedAt,
+    externalOrderId: input.executionLog.orderId,
+    failureReason,
+  })
+}
+
+function resolveExecutionMode(intent: IntentRecord) {
+  const rawMode = intent.metadata.executionMode
+  if (typeof rawMode !== 'string') {
+    return DEFAULT_EXECUTION_MODE
+  }
+
+  const parsedMode = ExecutionModeSchema.safeParse(rawMode.trim())
+  return parsedMode.success ? parsedMode.data : DEFAULT_EXECUTION_MODE
+}
+
+function extractFailureReason(executionLog: ExecutionLogRecord): string | undefined {
+  if (executionLog.status !== 'failed' && executionLog.status !== 'rejected') {
+    return undefined
+  }
+
+  const reason = executionLog.details.reason
+  return typeof reason === 'string' && reason.trim().length > 0
+    ? reason.trim()
+    : executionLog.status
+}

--- a/src/execution/service.test.ts
+++ b/src/execution/service.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import type { ExecutionLogRecord, ExecutionRequest, SignedExecutionRequest } from './contracts.js'
 import { FileExecutionRepository } from './repository.js'
 import { ExecutionPolicyError, ExecutionService, IntentStateError } from './service.js'
 
@@ -49,6 +50,31 @@ function createDeferredPromise<T>() {
   return { promise, resolve, reject }
 }
 
+function buildSignedRequest(request: ExecutionRequest): SignedExecutionRequest {
+  return {
+    ...request,
+    signerRef: 'mock:paper',
+    signature: `sig:${request.requestId}`,
+  }
+}
+
+function buildExecutionLog(
+  status: ExecutionLogRecord['status'],
+  overrides: Partial<ExecutionLogRecord> = {}
+): ExecutionLogRecord {
+  return {
+    logId: overrides.logId ?? `log-${status}`,
+    intentId: overrides.intentId ?? 'intent-1',
+    venue: overrides.venue ?? 'paper',
+    status,
+    recordedAt: overrides.recordedAt ?? '2026-04-18T12:00:01.000Z',
+    orderId: overrides.orderId ?? `venue-${status}-1`,
+    requestId: overrides.requestId ?? 'req-3',
+    preflightOk: overrides.preflightOk ?? true,
+    details: overrides.details ?? {},
+  }
+}
+
 describe('ExecutionService', () => {
   it('supports idempotent submit retries', () => {
     const { service } = buildService()
@@ -94,8 +120,8 @@ describe('ExecutionService', () => {
 
   it('records signer failures and keeps intent confirmable', async () => {
     const service = new ExecutionService({
-      signer: {
-        async signIntent() {
+      signingAdapter: {
+        async signExecutionRequest() {
           throw new Error('signer offline')
         },
       },
@@ -113,9 +139,17 @@ describe('ExecutionService', () => {
 
   it('records execution failures and keeps intent confirmed for retry', async () => {
     const service = new ExecutionService({
-      venueExecutor: {
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
         async placeOrder() {
           throw new Error('venue rejected order')
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
         },
       },
     })
@@ -134,12 +168,19 @@ describe('ExecutionService', () => {
 
   it('keeps the intent execution_pending when the venue returns a pending order', async () => {
     const service = new ExecutionService({
-      venueExecutor: {
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
         async placeOrder() {
-          return {
-            externalOrderId: 'venue-pending-1',
-            status: 'pending' as const,
-          }
+          return buildExecutionLog('accepted', {
+            orderId: 'venue-pending-1',
+          })
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
         },
       },
     })
@@ -151,18 +192,60 @@ describe('ExecutionService', () => {
 
     expect(result.status).toBe('execution_pending')
     expect(result.executedAt).toBeUndefined()
-    expect(result.orders.at(-1)?.status).toBe('pending')
+    expect(result.orders.at(-1)).toMatchObject({
+      status: 'pending',
+      externalOrderId: 'venue-pending-1',
+    })
+    expect(result.auditTrail.at(-1)?.type).toBe('execution_pending')
+  })
+
+  it('keeps the intent execution_pending when the venue returns a placed order', async () => {
+    const service = new ExecutionService({
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
+        async placeOrder() {
+          return buildExecutionLog('placed', {
+            orderId: 'venue-placed-1',
+          })
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
+        },
+      },
+    })
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+
+    const result = await service.executeIntent(intent.intentId, 'req-3')
+
+    expect(result.status).toBe('execution_pending')
+    expect(result.orders.at(-1)).toMatchObject({
+      status: 'placed',
+      externalOrderId: 'venue-placed-1',
+    })
     expect(result.auditTrail.at(-1)?.type).toBe('execution_pending')
   })
 
   it('keeps the intent confirmed when the venue returns a cancelled order', async () => {
     const service = new ExecutionService({
-      venueExecutor: {
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
         async placeOrder() {
-          return {
-            externalOrderId: 'venue-cancelled-1',
-            status: 'cancelled' as const,
-          }
+          return buildExecutionLog('cancelled', {
+            orderId: 'venue-cancelled-1',
+          })
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
         },
       },
     })
@@ -174,8 +257,47 @@ describe('ExecutionService', () => {
 
     expect(result.status).toBe('confirmed')
     expect(result.executedAt).toBeUndefined()
-    expect(result.orders.at(-1)?.status).toBe('cancelled')
+    expect(result.orders.at(-1)).toMatchObject({
+      status: 'cancelled',
+      externalOrderId: 'venue-cancelled-1',
+    })
     expect(result.auditTrail.at(-1)?.type).toBe('execution_cancelled')
+  })
+
+  it('keeps the intent confirmed when the venue returns a failed order', async () => {
+    const service = new ExecutionService({
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
+        async placeOrder() {
+          return buildExecutionLog('failed', {
+            orderId: 'venue-failed-1',
+            details: {
+              reason: 'insufficient depth',
+            },
+          })
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
+        },
+      },
+    })
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+
+    const result = await service.executeIntent(intent.intentId, 'req-3')
+
+    expect(result.status).toBe('confirmed')
+    expect(result.orders.at(-1)).toMatchObject({
+      status: 'failed',
+      externalOrderId: 'venue-failed-1',
+      failureReason: 'insufficient depth',
+    })
+    expect(result.auditTrail.at(-1)?.type).toBe('execution_failed')
   })
 
   it('blocks execution after ttl expiry', async () => {
@@ -201,10 +323,10 @@ describe('ExecutionService', () => {
   })
 
   it('rejects cancellation while execution is pending', async () => {
-    const signerGate = createDeferredPromise<{ signerRef: string }>()
+    const signerGate = createDeferredPromise<SignedExecutionRequest>()
     const service = new ExecutionService({
-      signer: {
-        async signIntent() {
+      signingAdapter: {
+        async signExecutionRequest(request) {
           return signerGate.promise
         },
       },
@@ -219,8 +341,69 @@ describe('ExecutionService', () => {
     expect(service.getIntent(intent.intentId).status).toBe('execution_pending')
     expect(() => service.cancelIntent(intent.intentId, 'req-4')).toThrowError(IntentStateError)
 
-    signerGate.resolve({ signerRef: 'local-signer:test' })
+    signerGate.resolve(
+      buildSignedRequest({
+        requestId: 'req-3',
+        intentId: intent.intentId,
+        venue: 'paper',
+        marketId: validIntent.market,
+        side: validIntent.side,
+        quantity: validIntent.quantity,
+        executionMode: 'taker',
+        submittedAt: '2026-04-18T12:00:00.000Z',
+      })
+    )
     await expect(executionPromise).resolves.toMatchObject({ status: 'executed' })
+  })
+
+  it('persists normalized execution logs in the durable repository', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'blackice-execution-logs-'))
+    tempDirs.push(dir)
+    const storagePath = path.join(dir, 'execution-state.json')
+
+    const repository = new FileExecutionRepository(storagePath)
+    const service = new ExecutionService({
+      repository,
+      now: () => new Date('2026-04-18T12:00:00.000Z'),
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
+        async placeOrder() {
+          return buildExecutionLog('filled', {
+            intentId: 'intent-filled',
+            orderId: 'venue-filled-1',
+          })
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
+        },
+      },
+    })
+
+    const { intent } = service.submitIntent(
+      {
+        ...validIntent,
+        intentId: 'intent-filled',
+        idempotencyKey: 'idem-filled',
+      },
+      'req-1'
+    )
+    service.confirmIntent(intent.intentId, 'req-2')
+    await service.executeIntent(intent.intentId, 'req-3')
+
+    const storedState = JSON.parse(readFileSync(storagePath, 'utf8')) as {
+      executionLogs: ExecutionLogRecord[]
+    }
+
+    expect(storedState.executionLogs).toHaveLength(1)
+    expect(storedState.executionLogs[0]).toMatchObject({
+      intentId: 'intent-filled',
+      status: 'filled',
+      orderId: 'venue-filled-1',
+    })
   })
 
   it('reloads intents from a durable repository across service instances', () => {

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -1,15 +1,26 @@
 import { randomUUID } from 'node:crypto'
 import { getRuntimeConfig } from '../config/runtimeConfig.js'
-import type { ExecutionRepository } from './contracts.js'
+import type {
+  ExecutionAdapter,
+  ExecutionRepository,
+  SignedExecutionRequest,
+  SigningAdapter,
+} from './contracts.js'
+import {
+  buildExecutionRequestFromIntent,
+  buildOrderRecordFromExecutionLog,
+  createExecutionAdapter,
+  mapExecutionLogToAuditEventType,
+  mapExecutionLogToIntentStatus,
+} from './executionAdapter.js'
 import { createExecutionRepository } from './repository.js'
+import { createSigningAdapter } from './signing.js'
 import {
   type AuditEvent,
   AuditEventSchema,
   type ExecutionPolicySnapshot,
   type IntentRecord,
   IntentRecordSchema,
-  type OrderRecord,
-  OrderRecordSchema,
   type SubmitIntentRequest,
 } from './schema.js'
 
@@ -43,20 +54,10 @@ export class IntentNotFoundError extends Error {
   }
 }
 
-export type Signer = {
-  signIntent(intent: IntentRecord): Promise<{ signerRef: string }>
-}
-
-export type VenueExecutor = {
-  placeOrder(
-    intent: IntentRecord
-  ): Promise<{ externalOrderId: string; status: OrderRecord['status'] }>
-}
-
 type ExecutionServiceOptions = {
   policy?: ExecutionPolicySnapshot
-  signer?: Signer
-  venueExecutor?: VenueExecutor
+  signingAdapter?: SigningAdapter
+  executionAdapter?: ExecutionAdapter
   repository?: ExecutionRepository
   now?: () => Date
 }
@@ -68,34 +69,17 @@ const DEFAULT_POLICY: ExecutionPolicySnapshot = {
   maxTtlSeconds: 86_400,
 }
 
-class InMemorySigner implements Signer {
-  async signIntent(intent: IntentRecord): Promise<{ signerRef: string }> {
-    return { signerRef: `local-signer:${intent.intentId}` }
-  }
-}
-
-class InMemoryVenueExecutor implements VenueExecutor {
-  async placeOrder(
-    intent: IntentRecord
-  ): Promise<{ externalOrderId: string; status: OrderRecord['status'] }> {
-    return {
-      externalOrderId: `paper-${intent.intentId}`,
-      status: 'filled',
-    }
-  }
-}
-
 export class ExecutionService {
   private readonly policy: ExecutionPolicySnapshot
-  private readonly signer: Signer
-  private readonly venueExecutor: VenueExecutor
+  private readonly signingAdapter: SigningAdapter
+  private readonly executionAdapter: ExecutionAdapter
   private readonly repository: ExecutionRepository
   private readonly now: () => Date
 
   constructor(options: ExecutionServiceOptions = {}) {
     this.policy = options.policy ?? DEFAULT_POLICY
-    this.signer = options.signer ?? new InMemorySigner()
-    this.venueExecutor = options.venueExecutor ?? new InMemoryVenueExecutor()
+    this.signingAdapter = options.signingAdapter ?? createSigningAdapter()
+    this.executionAdapter = options.executionAdapter ?? createExecutionAdapter()
     this.repository =
       options.repository ??
       createExecutionRepository({
@@ -221,16 +205,20 @@ export class ExecutionService {
     this.repository.saveIntent(intent)
     this.appendAuditEvent(intent, 'signing_requested', requestId, {})
 
+    const executionRequest = buildExecutionRequestFromIntent(intent, requestId, requestedAt)
+    let signedRequest: SignedExecutionRequest
+
     try {
-      const signed = await this.signer.signIntent(intent)
-      intent.signerRef = signed.signerRef
+      signedRequest = await this.signingAdapter.signExecutionRequest(executionRequest)
+      intent.signerRef = signedRequest.signerRef
       this.repository.saveIntent(intent)
       this.appendAuditEvent(intent, 'signing_succeeded', requestId, {
-        signerRef: signed.signerRef,
+        signerRef: signedRequest.signerRef,
       })
     } catch (error) {
+      const nowIso = this.now().toISOString()
       intent.status = 'confirmed'
-      intent.updatedAt = this.now().toISOString()
+      intent.updatedAt = nowIso
       this.repository.saveIntent(intent)
       this.appendAuditEvent(intent, 'signing_failed', requestId, {
         error: error instanceof Error ? error.message : String(error),
@@ -241,58 +229,33 @@ export class ExecutionService {
     this.appendAuditEvent(intent, 'execution_requested', requestId, {})
 
     try {
-      const execution = await this.venueExecutor.placeOrder(intent)
-      const nowIso = this.now().toISOString()
-      const order = OrderRecordSchema.parse({
-        orderId: randomUUID(),
-        venue: intent.venue,
-        market: intent.market,
-        side: intent.side,
-        quantity: intent.quantity,
-        limitPrice: intent.limitPrice,
-        notionalUsd: intent.notionalUsd,
-        status: execution.status,
-        createdAt: nowIso,
-        updatedAt: nowIso,
-        externalOrderId: execution.externalOrderId,
+      const executionLog = await this.executionAdapter.placeOrder(signedRequest)
+      this.repository.appendExecutionLog(executionLog)
+
+      const nowIso = executionLog.recordedAt
+      const order = buildOrderRecordFromExecutionLog({
+        intent,
+        executionLog,
+        recordedAt: nowIso,
       })
 
       intent.orders.push(order)
-      this.repository.saveIntent(intent)
-
-      if (execution.status === 'filled') {
-        intent.status = 'executed'
-        intent.executedAt = nowIso
-        intent.updatedAt = nowIso
-        this.repository.saveIntent(intent)
-        this.appendAuditEvent(intent, 'execution_succeeded', requestId, {
-          externalOrderId: execution.externalOrderId,
-          orderStatus: execution.status,
-        })
-        return intent
-      }
-
-      if (execution.status === 'pending' || execution.status === 'placed') {
-        intent.status = 'execution_pending'
-        intent.updatedAt = nowIso
-        this.repository.saveIntent(intent)
-        this.appendAuditEvent(intent, 'execution_pending', requestId, {
-          externalOrderId: execution.externalOrderId,
-          orderStatus: execution.status,
-        })
-        return intent
-      }
-
-      intent.status = 'confirmed'
+      intent.status = mapExecutionLogToIntentStatus(executionLog.status)
       intent.updatedAt = nowIso
+
+      if (intent.status === 'executed') {
+        intent.executedAt = nowIso
+      }
+
       this.repository.saveIntent(intent)
       this.appendAuditEvent(
         intent,
-        execution.status === 'cancelled' ? 'execution_cancelled' : 'execution_failed',
+        mapExecutionLogToAuditEventType(executionLog.status),
         requestId,
         {
-          externalOrderId: execution.externalOrderId,
-          orderStatus: execution.status,
+          externalOrderId: executionLog.orderId,
+          executionStatus: executionLog.status,
+          logId: executionLog.logId,
         }
       )
       return intent


### PR DESCRIPTION
Closes #150

## Summary
- add a dedicated execution adapter module for request building, paper execution, and normalized lifecycle mapping
- update `ExecutionService` to consume the shared signing and execution contracts instead of the previous ad hoc signer/venue executor path
- persist normalized execution logs and map venue results into consistent order, intent, and audit states

## Ownership Boundary
- issue boundary: execution adapter and normalized lifecycle tracking only
- depends on merged signing and repository contracts already on `main`
- avoids route wiring, discovery/orderbook changes, and repository redesign

## Files Touched
- `src/execution/executionAdapter.ts`
- `src/execution/executionAdapter.test.ts`
- `src/execution/service.ts`
- `src/execution/service.test.ts`

## Tests Run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/executionAdapter.test.ts src/execution/service.test.ts src/execution/signing.test.ts src/execution/repository.test.ts src/execution/contracts.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out Of Scope
- route updates in `src/routes/intents.ts` or `src/app.ts`
- discovery or orderbook adapter work
- preflight rules
- broad repository or schema redesign beyond the execution adapter flow
