### PR TITLE
feat(issue-147): add candidate preflight engine

### DIFF
--- a/src/execution/contracts.test.ts
+++ b/src/execution/contracts.test.ts
@@ -3,6 +3,7 @@ import {
   CandidateRecordSchema,
   EnrichedCandidateRecordSchema,
   ExecutionLogRecordSchema,
+  PreflightRequestSchema,
   ExecutionRequestSchema,
   PreflightResultSchema,
   SignedExecutionRequestSchema,
@@ -67,9 +68,32 @@ describe('execution foundation contracts', () => {
         },
       ],
     })
+    const preflightRequest = PreflightRequestSchema.parse({
+      candidate: {
+        marketId: 'mkt-1',
+        eventId: 'evt-1',
+        slug: 'btc-above-100k',
+        question: 'Will BTC close above 100k?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        qualificationStatus: 'eligible',
+        qualificationReasons: [],
+        orderbook: {
+          bestBid: 0.48,
+          bestAsk: 0.52,
+          spreadBps: 400,
+          depthUsd: 1200,
+          asOf: '2026-04-19T12:00:00.000Z',
+        },
+        impliedProbability: 0.5,
+      },
+      positionUsd: 250,
+    })
 
     expect(signedRequest.signature).toBe('signed-payload')
     expect(preflight.checks[0]?.code).toBe('spread_above_limit')
+    expect(preflightRequest.positionUsd).toBe(250)
   })
 
   it('parses execution log records and rejects invalid candidate data', () => {

--- a/src/execution/contracts.ts
+++ b/src/execution/contracts.ts
@@ -62,6 +62,12 @@ export const PreflightResultSchema = z.object({
   checks: z.array(PreflightCheckResultSchema).min(1),
 })
 
+export const PreflightRequestSchema = z.object({
+  candidate: EnrichedCandidateRecordSchema,
+  venue: z.string().min(1).optional(),
+  positionUsd: z.number().nonnegative().optional(),
+})
+
 export const ExecutionRequestSchema = z.object({
   requestId: z.string().min(1),
   intentId: z.string().min(1),
@@ -98,6 +104,7 @@ export type EnrichedCandidateRecord = z.infer<typeof EnrichedCandidateRecordSche
 export type PreflightCheckCode = z.infer<typeof PreflightCheckCodeSchema>
 export type PreflightCheckResult = z.infer<typeof PreflightCheckResultSchema>
 export type PreflightResult = z.infer<typeof PreflightResultSchema>
+export type PreflightRequest = z.infer<typeof PreflightRequestSchema>
 export type ExecutionRequest = z.infer<typeof ExecutionRequestSchema>
 export type SignedExecutionRequest = z.infer<typeof SignedExecutionRequestSchema>
 export type ExecutionLogRecord = z.infer<typeof ExecutionLogRecordSchema>
@@ -113,6 +120,10 @@ export type OrderbookReadAdapter = {
 
 export type CandidateEnrichmentAdapter = {
   listEnrichedCandidates(query: CandidateDiscoveryQuery): Promise<EnrichedCandidateRecord[]>
+}
+
+export type PreflightEvaluator = {
+  evaluate(request: PreflightRequest): Promise<PreflightResult>
 }
 
 export type SigningAdapter = {

--- a/src/execution/preflight.test.ts
+++ b/src/execution/preflight.test.ts
@@ -1,0 +1,209 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EnrichedCandidateRecord, SigningAdapter } from './contracts.js'
+
+const tempDirs: string[] = []
+
+function writeConfig(contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-preflight-config-'))
+  const file = path.join(dir, 'blackice.preflight.yaml')
+  writeFileSync(file, contents)
+  tempDirs.push(dir)
+  return file
+}
+
+function buildCandidate(overrides: Partial<EnrichedCandidateRecord> = {}): EnrichedCandidateRecord {
+  return {
+    marketId: 'market-147',
+    eventId: 'event-147',
+    slug: 'btc-above-150k',
+    question: 'Will BTC close above 150k?',
+    marketType: 'standard',
+    tradable: true,
+    metadataComplete: true,
+    tags: [],
+    qualificationStatus: 'eligible',
+    qualificationReasons: [],
+    orderbook: {
+      bestBid: 0.47,
+      bestAsk: 0.49,
+      spreadBps: 408.16,
+      depthUsd: 2_000,
+      asOf: '2026-04-23T01:00:00.000Z',
+    },
+    impliedProbability: 0.48,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('CandidatePreflightEngine', () => {
+  it('passes all checks for an eligible candidate with an available signer', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 1000
+  maxSpreadBps: 500
+execution:
+  defaultVenue: paper
+  allowedVenues:
+    - paper
+  maxPositionUsd: 1000
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { CandidatePreflightEngine } = await import('./preflight.js')
+    const signingAdapter: SigningAdapter = {
+      async signExecutionRequest(request) {
+        return {
+          ...request,
+          signerRef: 'mock:paper',
+          signature: 'sig-147',
+        }
+      },
+    }
+
+    const engine = new CandidatePreflightEngine({
+      signingAdapter,
+      now: () => new Date('2026-04-23T01:05:00.000Z'),
+    })
+    const result = await engine.evaluate({
+      candidate: buildCandidate(),
+      positionUsd: 250,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.venue).toBe('paper')
+    expect(result.checks.every((check) => check.ok)).toBe(true)
+  })
+
+  it('returns deterministic failures for candidate quality and position limits', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 1000
+  maxSpreadBps: 300
+execution:
+  defaultVenue: paper
+  allowedVenues:
+    - paper
+  maxPositionUsd: 500
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { CandidatePreflightEngine } = await import('./preflight.js')
+    const engine = new CandidatePreflightEngine({
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return {
+            ...request,
+            signerRef: 'mock:paper',
+            signature: 'sig-147',
+          }
+        },
+      },
+      now: () => new Date('2026-04-23T01:10:00.000Z'),
+    })
+
+    const result = await engine.evaluate({
+      candidate: buildCandidate({
+        tradable: false,
+        metadataComplete: false,
+        qualificationStatus: 'blocked',
+        qualificationReasons: ['candidate_not_tradable', 'metadata_incomplete'],
+        orderbook: {
+          bestBid: null,
+          bestAsk: 0.49,
+          spreadBps: 800,
+          depthUsd: 125,
+          asOf: '2026-04-23T01:09:00.000Z',
+        },
+        impliedProbability: 0.49,
+      }),
+      positionUsd: 750,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.checks.filter((check) => !check.ok).map((check) => check.code)).toEqual([
+      'candidate_not_tradable',
+      'metadata_incomplete',
+      'spread_above_limit',
+      'depth_below_minimum',
+      'position_above_limit',
+    ])
+  })
+
+  it('fails venue and signing checks when the venue is disallowed or signing setup is broken', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 0
+  maxSpreadBps: 500
+execution:
+  defaultVenue: paper
+  allowedVenues:
+    - paper
+  maxPositionUsd: 1000
+  signerKind: backend
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { CandidatePreflightEngine } = await import('./preflight.js')
+    const engine = new CandidatePreflightEngine({
+      now: () => new Date('2026-04-23T01:15:00.000Z'),
+    })
+
+    const result = await engine.evaluate({
+      candidate: buildCandidate(),
+      venue: 'live',
+      positionUsd: 100,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.checks.filter((check) => !check.ok).map((check) => check.code)).toEqual([
+      'venue_not_allowed',
+      'signing_unavailable',
+    ])
+    expect(result.checks.find((check) => check.code === 'signing_unavailable')?.message).toContain(
+      'BLACKICE_EXECUTION_SIGNER_REF is required for backend signing'
+    )
+  })
+
+  it('turns unsupported signer kinds into a failed signing check instead of throwing', async () => {
+    const configFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 0
+  maxSpreadBps: 500
+execution:
+  defaultVenue: paper
+  allowedVenues:
+    - paper
+  maxPositionUsd: 1000
+  signerKind: remote-kms
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { CandidatePreflightEngine } = await import('./preflight.js')
+    const engine = new CandidatePreflightEngine({
+      now: () => new Date('2026-04-23T01:20:00.000Z'),
+    })
+
+    const result = await engine.evaluate({
+      candidate: buildCandidate(),
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.checks.find((check) => check.code === 'signing_unavailable')?.message).toContain(
+      'Unsupported execution.signerKind: remote-kms'
+    )
+  })
+})

--- a/src/execution/preflight.ts
+++ b/src/execution/preflight.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from 'node:crypto'
+import { getRuntimeConfig } from '../config/runtimeConfig.js'
+import {
+  PreflightResultSchema,
+  PreflightRequestSchema,
+  type PreflightCheckCode,
+  type PreflightCheckResult,
+  type PreflightEvaluator,
+  type PreflightRequest,
+  type PreflightResult,
+  type SigningAdapter,
+} from './contracts.js'
+import { createSigningAdapter } from './signing.js'
+
+type Clock = () => Date
+
+type PreflightEngineOptions = {
+  now?: Clock
+  signingAdapter?: SigningAdapter
+}
+
+export class CandidatePreflightEngine implements PreflightEvaluator {
+  private readonly now: Clock
+  private readonly signingAdapter?: SigningAdapter
+
+  constructor(options: PreflightEngineOptions = {}) {
+    this.now = options.now ?? (() => new Date())
+    this.signingAdapter = options.signingAdapter
+  }
+
+  async evaluate(request: PreflightRequest): Promise<PreflightResult> {
+    const normalizedRequest = PreflightRequestSchema.parse(request)
+    const runtimeConfig = getRuntimeConfig()
+    const venue = normalizedRequest.venue ?? runtimeConfig.execution.defaultVenue
+    const checks = await buildChecks({
+      request: normalizedRequest,
+      venue,
+      signingAdapter: this.signingAdapter,
+      now: this.now,
+    })
+
+    return PreflightResultSchema.parse({
+      ok: checks.every((check) => check.ok),
+      checkedAt: this.now().toISOString(),
+      venue,
+      checks,
+    })
+  }
+}
+
+async function buildChecks(input: {
+  request: PreflightRequest
+  venue: string
+  signingAdapter?: SigningAdapter
+  now: Clock
+}): Promise<PreflightCheckResult[]> {
+  const runtimeConfig = getRuntimeConfig()
+  const candidate = input.request.candidate
+  const positionUsd = input.request.positionUsd ?? 0
+
+  return [
+    buildCheck(
+      'candidate_not_tradable',
+      candidate.tradable,
+      candidate.tradable ? 'Candidate is tradable' : 'Candidate is not tradable'
+    ),
+    buildCheck(
+      'metadata_incomplete',
+      candidate.metadataComplete,
+      candidate.metadataComplete
+        ? 'Candidate metadata is complete'
+        : 'Candidate metadata is incomplete'
+    ),
+    buildCheck(
+      'spread_above_limit',
+      candidate.orderbook.spreadBps === null ||
+        candidate.orderbook.spreadBps <= runtimeConfig.marketData.maxSpreadBps,
+      candidate.orderbook.spreadBps === null
+        ? 'Orderbook spread is unavailable but not over the configured limit'
+        : `Orderbook spread ${candidate.orderbook.spreadBps} bps is within configured limit ${runtimeConfig.marketData.maxSpreadBps} bps`,
+      candidate.orderbook.spreadBps === null
+        ? 'Orderbook spread is unavailable'
+        : `Orderbook spread ${candidate.orderbook.spreadBps} bps exceeds configured limit ${runtimeConfig.marketData.maxSpreadBps} bps`
+    ),
+    buildCheck(
+      'depth_below_minimum',
+      candidate.orderbook.depthUsd >= runtimeConfig.marketData.minDepthUsd,
+      `Orderbook depth ${candidate.orderbook.depthUsd} USD meets configured minimum ${runtimeConfig.marketData.minDepthUsd} USD`,
+      `Orderbook depth ${candidate.orderbook.depthUsd} USD is below configured minimum ${runtimeConfig.marketData.minDepthUsd} USD`
+    ),
+    buildCheck(
+      'position_above_limit',
+      positionUsd <= runtimeConfig.execution.maxPositionUsd,
+      `Requested position ${positionUsd} USD is within configured max ${runtimeConfig.execution.maxPositionUsd} USD`,
+      `Requested position ${positionUsd} USD exceeds configured max ${runtimeConfig.execution.maxPositionUsd} USD`
+    ),
+    buildCheck(
+      'venue_not_allowed',
+      runtimeConfig.execution.allowedVenues.includes(input.venue),
+      `Venue ${input.venue} is allowed`,
+      `Venue ${input.venue} is not allowed by policy`
+    ),
+    await buildSigningAvailabilityCheck(input),
+  ]
+}
+
+async function buildSigningAvailabilityCheck(input: {
+  request: PreflightRequest
+  venue: string
+  signingAdapter?: SigningAdapter
+  now: Clock
+}): Promise<PreflightCheckResult> {
+  try {
+    const signingAdapter = input.signingAdapter ?? createSigningAdapter()
+    await signingAdapter.signExecutionRequest({
+      requestId: `preflight-${randomUUID()}`,
+      intentId: `preflight-${input.request.candidate.marketId}`,
+      venue: input.venue,
+      marketId: input.request.candidate.marketId,
+      side: 'buy',
+      quantity: 1,
+      executionMode: 'taker',
+      submittedAt: input.now().toISOString(),
+    })
+
+    return buildCheck('signing_unavailable', true, 'Signing adapter is available')
+  } catch (error) {
+    return buildCheck(
+      'signing_unavailable',
+      false,
+      'Signing adapter is available',
+      `Signing adapter is unavailable: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+function buildCheck(
+  code: PreflightCheckCode,
+  ok: boolean,
+  successMessage: string,
+  failureMessage?: string
+): PreflightCheckResult {
+  return {
+    code,
+    ok,
+    message: ok ? successMessage : (failureMessage ?? successMessage),
+  }
+}


### PR DESCRIPTION
Closes #147

## Summary
- add a candidate preflight engine that evaluates enriched candidates against deterministic execution checks
- add a typed preflight request contract for later route integration without reworking issue `#147`
- cover pass/fail cases for candidate quality, depth/spread thresholds, venue policy, position sizing, and signer availability

## Ownership Boundary
- preflight engine only
- service-layer validation with no route wiring or execution-path changes

## Files Touched
- `src/execution/contracts.ts`
- `src/execution/contracts.test.ts`
- `src/execution/preflight.ts`
- `src/execution/preflight.test.ts`

## Tests Run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/preflight.test.ts src/execution/contracts.test.ts src/execution/enrichment.test.ts src/runtimeConfig.test.ts src/execution/signing.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out Of Scope
- route wiring
- intent execution changes
- discovery or orderbook adapter changes
- HTTP integration
