### PR TITLE
feat(issue-151): wire new service modules into HTTP routes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,8 +10,16 @@ import { registerModelRoutes } from './routes/models.js'
 import { registerOpsRoutes } from './routes/ops.js'
 import { registerIntentRoutes } from './routes/intents.js'
 import { checkReadiness, readinessStrict, readinessTimeoutMs } from './readiness.js'
+import type { CandidateEnrichmentAdapter, PreflightEvaluator } from './execution/contracts.js'
+import type { ExecutionService } from './execution/service.js'
 
-export function createApp(maxActiveDebates: number) {
+type CreateAppOptions = {
+  executionService?: ExecutionService
+  candidateEnrichmentAdapter?: CandidateEnrichmentAdapter
+  preflightEvaluator?: PreflightEvaluator
+}
+
+export function createApp(maxActiveDebates: number, options: CreateAppOptions = {}) {
   const app = express()
   const versionInfo = getVersionInfo()
 
@@ -29,7 +37,10 @@ export function createApp(maxActiveDebates: number) {
   registerDebateRoutes(app, maxActiveDebates)
   registerModelRoutes(app)
   registerOpsRoutes(app, versionInfo)
-  registerIntentRoutes(app)
+  registerIntentRoutes(app, options.executionService, {
+    candidateEnrichmentAdapter: options.candidateEnrichmentAdapter,
+    preflightEvaluator: options.preflightEvaluator,
+  })
 
   app.get('/readyz', async (_req, res) => {
     const readiness = await checkReadiness()

--- a/src/execution/schema.ts
+++ b/src/execution/schema.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod'
+import {
+  CandidateDiscoveryQuerySchema,
+  EnrichedCandidateRecordSchema,
+  PreflightRequestSchema,
+  PreflightResultSchema,
+} from './contracts.js'
 
 export const IntentStatusSchema = z.enum([
   'submitted',
@@ -108,9 +114,33 @@ export const IntentActionResponseSchema = z.object({
   intent: IntentRecordSchema,
 })
 
+export const ExecuteIntentRequestSchema = z
+  .object({
+    preflight: PreflightRequestSchema.optional(),
+  })
+  .default({})
+
+export const ExecuteIntentResponseSchema = z.object({
+  ok: z.literal(true),
+  intent: IntentRecordSchema,
+  preflight: PreflightResultSchema.optional(),
+})
+
 export const ListIntentsResponseSchema = z.object({
   ok: z.literal(true),
   intents: z.array(IntentRecordSchema),
+})
+
+export const ListCandidatesRequestSchema = CandidateDiscoveryQuerySchema
+
+export const ListCandidatesResponseSchema = z.object({
+  ok: z.literal(true),
+  candidates: z.array(EnrichedCandidateRecordSchema),
+})
+
+export const PreflightActionResponseSchema = z.object({
+  ok: z.literal(true),
+  preflight: PreflightResultSchema,
 })
 
 export type SubmitIntentRequest = z.input<typeof SubmitIntentRequestSchema>

--- a/src/routes.integration.test.ts
+++ b/src/routes.integration.test.ts
@@ -7,6 +7,44 @@ vi.mock('./actions.js', () => ({
   executeAction: vi.fn(async () => ({ action: 'healthcheck', text: 'ok-healthcheck' })),
 }))
 
+function buildEnrichedCandidate() {
+  return {
+    marketId: 'market-http-1',
+    eventId: 'event-http-1',
+    slug: 'btc-above-100k',
+    question: 'Will BTC close above 100k?',
+    marketType: 'standard' as const,
+    tradable: true,
+    metadataComplete: true,
+    tags: [],
+    qualificationStatus: 'eligible' as const,
+    qualificationReasons: [],
+    orderbook: {
+      bestBid: 0.48,
+      bestAsk: 0.5,
+      spreadBps: 400,
+      depthUsd: 1200,
+      asOf: '2026-04-23T00:00:00.000Z',
+    },
+    impliedProbability: 0.49,
+  }
+}
+
+function buildPreflightResult(ok = true) {
+  return {
+    ok,
+    checkedAt: '2026-04-23T00:01:00.000Z',
+    venue: 'paper',
+    checks: [
+      {
+        code: ok ? 'candidate_not_tradable' : 'spread_above_limit',
+        ok,
+        message: ok ? 'Candidate is tradable' : 'Spread exceeds configured limit',
+      },
+    ],
+  }
+}
+
 describe('integration routes', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -260,7 +298,11 @@ describe('integration routes', () => {
 
   it('POST /v1/intents/:intentId/confirm and /execute complete the lifecycle', async () => {
     const { createApp } = await import('./app.js')
-    const app = createApp(1)
+    const app = createApp(1, {
+      preflightEvaluator: {
+        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(true)),
+      },
+    })
 
     const submit = await request(app).post('/v1/intents').send({
       idempotencyKey: 'idem-http-3',
@@ -275,13 +317,20 @@ describe('integration routes', () => {
     const intentId = submit.body.intent.intentId
 
     const confirm = await request(app).post(`/v1/intents/${intentId}/confirm`).send({})
-    const execute = await request(app).post(`/v1/intents/${intentId}/execute`).send({})
+    const execute = await request(app)
+      .post(`/v1/intents/${intentId}/execute`)
+      .send({
+        preflight: {
+          candidate: buildEnrichedCandidate(),
+        },
+      })
 
     expect(confirm.status).toBe(200)
     expect(confirm.body.intent.status).toBe('confirmed')
     expect(execute.status).toBe(200)
     expect(execute.body.intent.status).toBe('executed')
     expect(execute.body.intent.orders).toHaveLength(1)
+    expect(execute.body.preflight.ok).toBe(true)
   })
 
   it('POST /v1/intents rejects disallowed venues', async () => {
@@ -301,6 +350,93 @@ describe('integration routes', () => {
 
     expect(res.status).toBe(422)
     expect(res.body.code).toBe('venue_not_allowed')
+  })
+
+  it('GET /v1/candidates returns enriched candidates from the route adapter', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1, {
+      candidateEnrichmentAdapter: {
+        listEnrichedCandidates: vi.fn().mockResolvedValue([buildEnrichedCandidate()]),
+      },
+    })
+
+    const res = await request(app).get('/v1/candidates?limit=5')
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.candidates).toHaveLength(1)
+    expect(res.body.candidates[0].marketId).toBe('market-http-1')
+  })
+
+  it('GET /v1/candidates rejects invalid query parameters', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1, {
+      candidateEnrichmentAdapter: {
+        listEnrichedCandidates: vi.fn().mockResolvedValue([]),
+      },
+    })
+
+    const res = await request(app).get('/v1/candidates?limit=abc')
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('Invalid query parameters')
+  })
+
+  it('POST /v1/preflight returns a structured preflight result', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1, {
+      preflightEvaluator: {
+        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(true)),
+      },
+    })
+
+    const res = await request(app).post('/v1/preflight').send({
+      candidate: buildEnrichedCandidate(),
+      positionUsd: 250,
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.preflight.ok).toBe(true)
+    expect(res.body.preflight.venue).toBe('paper')
+  })
+
+  it('POST /v1/intents/:intentId/execute blocks execution when preflight is missing or failed', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1, {
+      preflightEvaluator: {
+        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(false)),
+      },
+    })
+
+    const submit = await request(app).post('/v1/intents').send({
+      idempotencyKey: 'idem-http-5',
+      accountId: 'acct-primary',
+      market: 'DOGE-USD',
+      venue: 'paper',
+      side: 'buy',
+      quantity: 5,
+      notionalUsd: 250,
+      ttlSeconds: 300,
+    })
+    const intentId = submit.body.intent.intentId
+
+    await request(app).post(`/v1/intents/${intentId}/confirm`).send({})
+
+    const missingPreflight = await request(app).post(`/v1/intents/${intentId}/execute`).send({})
+    const failedPreflight = await request(app)
+      .post(`/v1/intents/${intentId}/execute`)
+      .send({
+        preflight: {
+          candidate: buildEnrichedCandidate(),
+        },
+      })
+
+    expect(missingPreflight.status).toBe(422)
+    expect(missingPreflight.body.code).toBe('preflight_required')
+    expect(failedPreflight.status).toBe(422)
+    expect(failedPreflight.body.code).toBe('preflight_failed')
+    expect(failedPreflight.body.preflight.ok).toBe(false)
   })
 
   it('POST /analyze/logs returns validation error for bad payload', async () => {

--- a/src/routes/intents.ts
+++ b/src/routes/intents.ts
@@ -1,8 +1,13 @@
 import type { Express, Request, Response } from 'express'
+import { getRuntimeConfig } from '../config/runtimeConfig.js'
 import { log } from '../log.js'
 import { sendSimpleError } from '../http/errors.js'
 import { parseBodyOrRespond } from '../http/validation.js'
 import { getRequestId } from '../http/requestLogging.js'
+import { PublicCandidateDiscoveryAdapter } from '../execution/discovery.js'
+import { CandidateEnrichmentPipeline } from '../execution/enrichment.js'
+import { PublicOrderbookReadAdapter } from '../execution/orderbook.js'
+import { CandidatePreflightEngine } from '../execution/preflight.js'
 import {
   ExecutionPolicyError,
   ExecutionService,
@@ -12,15 +17,90 @@ import {
 import {
   IntentActionResponseSchema,
   IntentStatusSchema,
+  ExecuteIntentRequestSchema,
+  ExecuteIntentResponseSchema,
+  ListCandidatesResponseSchema,
+  ListCandidatesRequestSchema,
   ListIntentsResponseSchema,
+  PreflightActionResponseSchema,
   SubmitIntentRequestSchema,
   SubmitIntentResponseSchema,
 } from '../execution/schema.js'
+import {
+  PreflightRequestSchema,
+  type CandidateEnrichmentAdapter,
+  type PreflightEvaluator,
+} from '../execution/contracts.js'
+
+type IntentRouteOptions = {
+  candidateEnrichmentAdapter?: CandidateEnrichmentAdapter
+  preflightEvaluator?: PreflightEvaluator
+}
 
 export function registerIntentRoutes(
   app: Express,
-  executionService = new ExecutionService()
+  executionService = new ExecutionService(),
+  options: IntentRouteOptions = {}
 ): void {
+  const candidateEnrichmentAdapter =
+    options.candidateEnrichmentAdapter ??
+    new CandidateEnrichmentPipeline({
+      discoveryAdapter: new PublicCandidateDiscoveryAdapter(),
+      orderbookAdapter: new PublicOrderbookReadAdapter(),
+    })
+  const preflightEvaluator = options.preflightEvaluator ?? new CandidatePreflightEngine()
+
+  app.get('/v1/candidates', async (req: Request, res: Response) => {
+    const parsed = ListCandidatesRequestSchema.safeParse({
+      limit: parseOptionalInt(req.query.limit),
+      excludedEventTypes: parseOptionalStringArray(req.query.excludedEventTypes),
+    })
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Invalid query parameters',
+        details: parsed.error.issues,
+      })
+      return
+    }
+
+    try {
+      const candidates = await candidateEnrichmentAdapter.listEnrichedCandidates(parsed.data)
+      res.status(200).json(
+        ListCandidatesResponseSchema.parse({
+          ok: true,
+          candidates,
+        })
+      )
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
+  app.post('/v1/preflight', async (req: Request, res: Response) => {
+    const requestId = getRequestId(res)
+    const parsed = parseBodyOrRespond(PreflightRequestSchema, req.body, res)
+    if (!parsed) {
+      return
+    }
+
+    try {
+      const preflight = await preflightEvaluator.evaluate(parsed)
+      log.info('preflight_evaluated', {
+        request_id: requestId,
+        venue: preflight.venue,
+        ok: preflight.ok,
+      })
+      res.status(200).json(
+        PreflightActionResponseSchema.parse({
+          ok: true,
+          preflight,
+        })
+      )
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
   app.post('/v1/intents', (req: Request, res: Response) => {
     const requestId = getRequestId(res)
     const parsed = parseBodyOrRespond(SubmitIntentRequestSchema, req.body, res)
@@ -93,8 +173,47 @@ export function registerIntentRoutes(
   app.post('/v1/intents/:intentId/execute', async (req: Request, res: Response) => {
     try {
       const requestId = getRequestId(res)
-      const intent = await executionService.executeIntent(req.params.intentId, requestId)
-      res.status(200).json(IntentActionResponseSchema.parse({ ok: true, intent }))
+      const parsed = parseBodyOrRespond(ExecuteIntentRequestSchema, req.body ?? {}, res)
+      if (!parsed) {
+        return
+      }
+
+      const intent = executionService.getIntent(req.params.intentId)
+      let preflight = undefined
+
+      if (parsed.preflight) {
+        preflight = await preflightEvaluator.evaluate({
+          ...parsed.preflight,
+          venue: intent.venue,
+          positionUsd: intent.notionalUsd,
+        })
+      }
+
+      if (requirePreflightExecution() && !preflight) {
+        res.status(422).json({
+          error: 'Preflight is required before execution',
+          code: 'preflight_required',
+        })
+        return
+      }
+
+      if (preflight && !preflight.ok) {
+        res.status(422).json({
+          error: 'Preflight failed',
+          code: 'preflight_failed',
+          preflight,
+        })
+        return
+      }
+
+      const executedIntent = await executionService.executeIntent(req.params.intentId, requestId)
+      res.status(200).json(
+        ExecuteIntentResponseSchema.parse({
+          ok: true,
+          intent: executedIntent,
+          preflight,
+        })
+      )
     } catch (error) {
       respondExecutionError(res, error)
     }
@@ -131,4 +250,28 @@ function respondExecutionError(res: Response, error: unknown): void {
   }
 
   sendSimpleError(res, 500, error instanceof Error ? error.message : 'Internal server error')
+}
+
+function requirePreflightExecution(): boolean {
+  return getRuntimeConfig().execution.requirePreflight
+}
+
+function parseOptionalInt(value: unknown): number | undefined {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return undefined
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isNaN(parsed) ? Number.NaN : parsed
+}
+
+function parseOptionalStringArray(value: unknown): string[] | undefined {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return undefined
+  }
+
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
 }


### PR DESCRIPTION
Closes #151

## Summary
- add route wiring for candidate listing and standalone preflight evaluation
- gate intent execution behind optional preflight input when runtime config requires it
- extend app injection points and integration tests so HTTP behavior stays deterministic and covered

## Ownership Boundary
- HTTP/API integration only
- consumes merged discovery, enrichment, preflight, repository, signing, and execution modules without redefining them

## Files Touched
- `src/app.ts`
- `src/execution/schema.ts`
- `src/routes/intents.ts`
- `src/routes.integration.test.ts`

## Tests Run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/routes.integration.test.ts src/execution/contracts.test.ts src/execution/preflight.test.ts src/execution/service.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out Of Scope
- discovery/orderbook adapter internals
- preflight rule design
- persistence redesign
- execution adapter internals
