### PR TITLE
feat: persist intent-bound preflight records

### DIFF
--- a/src/execution/contracts.test.ts
+++ b/src/execution/contracts.test.ts
@@ -3,6 +3,7 @@ import {
   CandidateRecordSchema,
   EnrichedCandidateRecordSchema,
   ExecutionLogRecordSchema,
+  PreflightRecordSchema,
   PreflightRequestSchema,
   ExecutionRequestSchema,
   PreflightResultSchema,
@@ -90,10 +91,19 @@ describe('execution foundation contracts', () => {
       },
       positionUsd: 250,
     })
+    const preflightRecord = PreflightRecordSchema.parse({
+      preflightId: 'preflight-1',
+      intentId: 'intent-1',
+      recordedAt: '2026-04-19T12:00:01.000Z',
+      policyFingerprint: 'fingerprint-1',
+      request: preflightRequest,
+      result: preflight,
+    })
 
     expect(signedRequest.signature).toBe('signed-payload')
     expect(preflight.checks[0]?.code).toBe('spread_above_limit')
     expect(preflightRequest.positionUsd).toBe(250)
+    expect(preflightRecord.policyFingerprint).toBe('fingerprint-1')
   })
 
   it('parses execution log records and rejects invalid candidate data', () => {

--- a/src/execution/contracts.ts
+++ b/src/execution/contracts.ts
@@ -68,6 +68,15 @@ export const PreflightRequestSchema = z.object({
   positionUsd: z.number().nonnegative().optional(),
 })
 
+export const PreflightRecordSchema = z.object({
+  preflightId: z.string().min(1),
+  intentId: z.string().min(1),
+  recordedAt: z.string().datetime(),
+  policyFingerprint: z.string().min(1),
+  request: PreflightRequestSchema,
+  result: PreflightResultSchema,
+})
+
 export const ExecutionRequestSchema = z.object({
   requestId: z.string().min(1),
   intentId: z.string().min(1),
@@ -105,6 +114,7 @@ export type PreflightCheckCode = z.infer<typeof PreflightCheckCodeSchema>
 export type PreflightCheckResult = z.infer<typeof PreflightCheckResultSchema>
 export type PreflightResult = z.infer<typeof PreflightResultSchema>
 export type PreflightRequest = z.infer<typeof PreflightRequestSchema>
+export type PreflightRecord = z.infer<typeof PreflightRecordSchema>
 export type ExecutionRequest = z.infer<typeof ExecutionRequestSchema>
 export type SignedExecutionRequest = z.infer<typeof SignedExecutionRequestSchema>
 export type ExecutionLogRecord = z.infer<typeof ExecutionLogRecordSchema>
@@ -142,5 +152,8 @@ export type ExecutionRepository = {
   getIntentIdByIdempotencyKey(idempotencyKey: string): string | null
   saveIdempotencyKey(idempotencyKey: string, intentId: string): void
   appendAuditEvent(event: AuditEvent): void
+  listPreflightRecords(intentId: string): PreflightRecord[]
+  getLatestPreflightRecord(intentId: string): PreflightRecord | null
+  appendPreflightRecord(record: PreflightRecord): void
   appendExecutionLog(record: ExecutionLogRecord): void
 }

--- a/src/execution/preflight.test.ts
+++ b/src/execution/preflight.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { EnrichedCandidateRecord, SigningAdapter } from './contracts.js'
+import type { EnrichedCandidateRecord, PreflightRequest, SigningAdapter } from './contracts.js'
 
 const tempDirs: string[] = []
 
@@ -34,6 +34,15 @@ function buildCandidate(overrides: Partial<EnrichedCandidateRecord> = {}): Enric
       asOf: '2026-04-23T01:00:00.000Z',
     },
     impliedProbability: 0.48,
+    ...overrides,
+  }
+}
+
+function buildPreflightRequest(overrides: Partial<PreflightRequest> = {}): PreflightRequest {
+  return {
+    candidate: buildCandidate(),
+    venue: 'paper',
+    positionUsd: 250,
     ...overrides,
   }
 }
@@ -205,5 +214,47 @@ execution:
     expect(result.checks.find((check) => check.code === 'signing_unavailable')?.message).toContain(
       'Unsupported execution.signerKind: remote-kms'
     )
+  })
+
+  it('computes stable policy fingerprints and changes them when config changes', async () => {
+    const firstConfigFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 1000
+  maxSpreadBps: 500
+execution:
+  defaultVenue: paper
+  allowedVenues:
+    - paper
+  maxPositionUsd: 1000
+  signerKind: mock
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', firstConfigFile)
+    const { computePreflightPolicyFingerprint } = await import('./preflight.js')
+    const firstFingerprint = computePreflightPolicyFingerprint(buildPreflightRequest())
+    const secondFingerprint = computePreflightPolicyFingerprint(buildPreflightRequest())
+
+    expect(firstFingerprint).toBe(secondFingerprint)
+
+    vi.resetModules()
+    const secondConfigFile = writeConfig(`version: 1
+marketData:
+  minDepthUsd: 1500
+  maxSpreadBps: 500
+execution:
+  defaultVenue: paper
+  allowedVenues:
+    - paper
+  maxPositionUsd: 1000
+  signerKind: mock
+`)
+    vi.stubEnv('BLACKICE_CONFIG_FILE', secondConfigFile)
+
+    const { computePreflightPolicyFingerprint: computeWithChangedConfig } = await import(
+      './preflight.js'
+    )
+    const changedFingerprint = computeWithChangedConfig(buildPreflightRequest())
+
+    expect(changedFingerprint).not.toBe(firstFingerprint)
   })
 })

--- a/src/execution/preflight.ts
+++ b/src/execution/preflight.ts
@@ -1,11 +1,13 @@
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { getRuntimeConfig } from '../config/runtimeConfig.js'
 import {
+  PreflightRecordSchema,
   PreflightResultSchema,
   PreflightRequestSchema,
   type PreflightCheckCode,
   type PreflightCheckResult,
   type PreflightEvaluator,
+  type PreflightRecord,
   type PreflightRequest,
   type PreflightResult,
   type SigningAdapter,
@@ -46,6 +48,50 @@ export class CandidatePreflightEngine implements PreflightEvaluator {
       checks,
     })
   }
+}
+
+export function buildPreflightRecord(input: {
+  intentId: string
+  recordedAt: string
+  request: PreflightRequest
+  result: PreflightResult
+}): PreflightRecord {
+  const normalizedRequest = PreflightRequestSchema.parse(input.request)
+  const normalizedResult = PreflightResultSchema.parse(input.result)
+
+  return PreflightRecordSchema.parse({
+    preflightId: randomUUID(),
+    intentId: input.intentId,
+    recordedAt: input.recordedAt,
+    policyFingerprint: computePreflightPolicyFingerprint(normalizedRequest),
+    request: normalizedRequest,
+    result: normalizedResult,
+  })
+}
+
+export function computePreflightPolicyFingerprint(request: PreflightRequest): string {
+  const normalizedRequest = PreflightRequestSchema.parse(request)
+  const runtimeConfig = getRuntimeConfig()
+
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        version: 1,
+        request: normalizedRequest,
+        marketData: {
+          minDepthUsd: runtimeConfig.marketData.minDepthUsd,
+          maxSpreadBps: runtimeConfig.marketData.maxSpreadBps,
+        },
+        execution: {
+          defaultVenue: runtimeConfig.execution.defaultVenue,
+          allowedVenues: runtimeConfig.execution.allowedVenues,
+          requirePreflight: runtimeConfig.execution.requirePreflight,
+          maxPositionUsd: runtimeConfig.execution.maxPositionUsd,
+          signerKind: runtimeConfig.execution.signerKind,
+        },
+      })
+    )
+    .digest('hex')
 }
 
 async function buildChecks(input: {

--- a/src/execution/repository.test.ts
+++ b/src/execution/repository.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { IntentRecord } from './schema.js'
+import type { PreflightRecord } from './contracts.js'
 import { FileExecutionRepository, InMemoryExecutionRepository } from './repository.js'
 
 const tempDirs: string[] = []
@@ -35,6 +36,52 @@ function buildIntent(overrides: Partial<IntentRecord> = {}): IntentRecord {
   }
 }
 
+function buildPreflightRecord(overrides: Partial<PreflightRecord> = {}): PreflightRecord {
+  return {
+    preflightId: 'preflight-1',
+    intentId: 'intent-1',
+    recordedAt: '2026-04-21T00:01:00.000Z',
+    policyFingerprint: 'fingerprint-1',
+    request: {
+      candidate: {
+        marketId: 'market-1',
+        eventId: 'event-1',
+        slug: 'btc-above-100k',
+        question: 'Will BTC close above 100k?',
+        marketType: 'standard',
+        tradable: true,
+        metadataComplete: true,
+        qualificationStatus: 'eligible',
+        qualificationReasons: [],
+        orderbook: {
+          bestBid: 0.48,
+          bestAsk: 0.5,
+          spreadBps: 400,
+          depthUsd: 1200,
+          asOf: '2026-04-21T00:00:00.000Z',
+        },
+        impliedProbability: 0.49,
+        tags: [],
+      },
+      venue: 'paper',
+      positionUsd: 1000,
+    },
+    result: {
+      ok: true,
+      checkedAt: '2026-04-21T00:01:00.000Z',
+      venue: 'paper',
+      checks: [
+        {
+          code: 'candidate_not_tradable',
+          ok: true,
+          message: 'Candidate is tradable',
+        },
+      ],
+    },
+    ...overrides,
+  }
+}
+
 afterEach(() => {
   while (tempDirs.length > 0) {
     rmSync(tempDirs.pop() as string, { recursive: true, force: true })
@@ -45,29 +92,39 @@ describe('execution repositories', () => {
   it('stores and retrieves intents in memory', () => {
     const repository = new InMemoryExecutionRepository()
     const intent = buildIntent()
+    const preflightRecord = buildPreflightRecord()
 
     repository.saveIntent(intent)
     repository.saveIdempotencyKey(intent.idempotencyKey, intent.intentId)
+    repository.appendPreflightRecord(preflightRecord)
 
     expect(repository.getIntent(intent.intentId)).toMatchObject(intent)
     expect(repository.getIntentIdByIdempotencyKey(intent.idempotencyKey)).toBe(intent.intentId)
+    expect(repository.getLatestPreflightRecord(intent.intentId)).toMatchObject(preflightRecord)
   })
 
   it('persists intents to disk across repository instances', () => {
     const storagePath = makeTempPath('execution-state.json')
     const firstRepository = new FileExecutionRepository(storagePath)
     const intent = buildIntent()
+    const preflightRecord = buildPreflightRecord()
 
     firstRepository.saveIntent(intent)
     firstRepository.saveIdempotencyKey(intent.idempotencyKey, intent.intentId)
+    firstRepository.appendPreflightRecord(preflightRecord)
 
     const secondRepository = new FileExecutionRepository(storagePath)
     expect(secondRepository.getIntent(intent.intentId)).toMatchObject(intent)
     expect(secondRepository.getIntentIdByIdempotencyKey(intent.idempotencyKey)).toBe(
       intent.intentId
     )
+    expect(secondRepository.listPreflightRecords(intent.intentId)).toHaveLength(1)
+    expect(secondRepository.getLatestPreflightRecord(intent.intentId)).toMatchObject(
+      preflightRecord
+    )
 
     const persisted = JSON.parse(readFileSync(storagePath, 'utf8'))
     expect(persisted.idempotencyKeys[intent.idempotencyKey]).toBe(intent.intentId)
+    expect(persisted.preflightRecords).toHaveLength(1)
   })
 })

--- a/src/execution/repository.ts
+++ b/src/execution/repository.ts
@@ -1,18 +1,25 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
-import type { ExecutionLogRecord, ExecutionRepository } from './contracts.js'
+import {
+  PreflightRecordSchema,
+  type ExecutionLogRecord,
+  type ExecutionRepository,
+  type PreflightRecord,
+} from './contracts.js'
 import type { IntentRecord, IntentStatus } from './schema.js'
 import { AuditEventSchema, IntentRecordSchema } from './schema.js'
 
 type StoredExecutionState = {
   intents: Record<string, IntentRecord>
   idempotencyKeys: Record<string, string>
+  preflightRecords: PreflightRecord[]
   executionLogs: ExecutionLogRecord[]
 }
 
 const EMPTY_STATE: StoredExecutionState = {
   intents: {},
   idempotencyKeys: {},
+  preflightRecords: [],
   executionLogs: [],
 }
 
@@ -26,6 +33,7 @@ function cloneState(state: StoredExecutionState): StoredExecutionState {
       Object.entries(state.intents).map(([intentId, intent]) => [intentId, cloneIntent(intent)])
     ),
     idempotencyKeys: { ...state.idempotencyKeys },
+    preflightRecords: structuredClone(state.preflightRecords),
     executionLogs: structuredClone(state.executionLogs),
   }
 }
@@ -42,6 +50,9 @@ function parseState(raw: string): StoredExecutionState {
   return {
     intents,
     idempotencyKeys: { ...(parsed.idempotencyKeys ?? {}) },
+    preflightRecords: (parsed.preflightRecords ?? []).map((record) =>
+      PreflightRecordSchema.parse(record)
+    ),
     executionLogs: structuredClone(parsed.executionLogs ?? []),
   }
 }
@@ -85,6 +96,21 @@ export class InMemoryExecutionRepository implements ExecutionRepository {
     const nextIntent = cloneIntent(intent)
     nextIntent.auditTrail.push(parsedEvent)
     this.state.intents[parsedEvent.intentId] = nextIntent
+  }
+
+  listPreflightRecords(intentId: string): PreflightRecord[] {
+    return this.state.preflightRecords
+      .filter((record) => record.intentId === intentId)
+      .map((record) => PreflightRecordSchema.parse(structuredClone(record)))
+  }
+
+  getLatestPreflightRecord(intentId: string): PreflightRecord | null {
+    const records = this.listPreflightRecords(intentId)
+    return records.at(-1) ?? null
+  }
+
+  appendPreflightRecord(record: PreflightRecord): void {
+    this.state.preflightRecords.push(PreflightRecordSchema.parse(structuredClone(record)))
   }
 
   appendExecutionLog(record: ExecutionLogRecord): void {
@@ -135,6 +161,23 @@ export class FileExecutionRepository implements ExecutionRepository {
     const nextIntent = cloneIntent(intent)
     nextIntent.auditTrail.push(parsedEvent)
     state.intents[parsedEvent.intentId] = nextIntent
+    this.writeState(state)
+  }
+
+  listPreflightRecords(intentId: string): PreflightRecord[] {
+    return this.readState()
+      .preflightRecords.filter((record) => record.intentId === intentId)
+      .map((record) => PreflightRecordSchema.parse(structuredClone(record)))
+  }
+
+  getLatestPreflightRecord(intentId: string): PreflightRecord | null {
+    const records = this.listPreflightRecords(intentId)
+    return records.at(-1) ?? null
+  }
+
+  appendPreflightRecord(record: PreflightRecord): void {
+    const state = this.readState()
+    state.preflightRecords.push(PreflightRecordSchema.parse(structuredClone(record)))
     this.writeState(state)
   }
 

--- a/src/execution/schema.ts
+++ b/src/execution/schema.ts
@@ -21,6 +21,7 @@ export const AuditEventTypeSchema = z.enum([
   'intent_submitted',
   'intent_confirmed',
   'intent_rejected',
+  'preflight_recorded',
   'signing_requested',
   'signing_succeeded',
   'signing_failed',

--- a/src/execution/service.test.ts
+++ b/src/execution/service.test.ts
@@ -2,7 +2,13 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import type { ExecutionLogRecord, ExecutionRequest, SignedExecutionRequest } from './contracts.js'
+import type {
+  ExecutionLogRecord,
+  ExecutionRequest,
+  PreflightRequest,
+  PreflightResult,
+  SignedExecutionRequest,
+} from './contracts.js'
 import { FileExecutionRepository } from './repository.js'
 import { ExecutionPolicyError, ExecutionService, IntentStateError } from './service.js'
 
@@ -75,6 +81,48 @@ function buildExecutionLog(
   }
 }
 
+function buildPreflightRequest(overrides: Partial<PreflightRequest> = {}): PreflightRequest {
+  return {
+    candidate: {
+      marketId: 'market-1',
+      eventId: 'event-1',
+      slug: 'btc-above-100k',
+      question: 'Will BTC close above 100k?',
+      marketType: 'standard',
+      tradable: true,
+      metadataComplete: true,
+      qualificationStatus: 'eligible',
+      qualificationReasons: [],
+      orderbook: {
+        bestBid: 0.48,
+        bestAsk: 0.5,
+        spreadBps: 400,
+        depthUsd: 1200,
+        asOf: '2026-04-18T12:00:00.000Z',
+      },
+      impliedProbability: 0.49,
+      tags: [],
+    },
+    ...overrides,
+  }
+}
+
+function buildPreflightResult(overrides: Partial<PreflightResult> = {}): PreflightResult {
+  return {
+    ok: true,
+    checkedAt: '2026-04-18T12:00:00.000Z',
+    venue: 'paper',
+    checks: [
+      {
+        code: 'candidate_not_tradable',
+        ok: true,
+        message: 'Candidate is tradable',
+      },
+    ],
+    ...overrides,
+  }
+}
+
 describe('ExecutionService', () => {
   it('supports idempotent submit retries', () => {
     const { service } = buildService()
@@ -85,6 +133,58 @@ describe('ExecutionService', () => {
     expect(first.created).toBe(true)
     expect(second.created).toBe(false)
     expect(second.intent.intentId).toBe(first.intent.intentId)
+  })
+
+  it('records intent-bound preflight records and returns the latest one', () => {
+    const { service } = buildService()
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    const record = service.recordPreflight(
+      intent.intentId,
+      buildPreflightRequest(),
+      buildPreflightResult(),
+      'req-2'
+    )
+
+    expect(record.intentId).toBe(intent.intentId)
+    expect(record.request.venue).toBe(intent.venue)
+    expect(record.request.positionUsd).toBe(intent.notionalUsd)
+    expect(service.getLatestPreflightRecord(intent.intentId)?.preflightId).toBe(record.preflightId)
+    expect(service.listPreflightRecords(intent.intentId)).toHaveLength(1)
+    expect(service.getIntent(intent.intentId).auditTrail.at(-1)?.type).toBe('preflight_recorded')
+  })
+
+  it('rejects preflight records whose venue or position do not match the intent', () => {
+    const { service } = buildService()
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+
+    expect(() =>
+      service.recordPreflight(
+        intent.intentId,
+        buildPreflightRequest({ venue: 'live' }),
+        buildPreflightResult(),
+        'req-2'
+      )
+    ).toThrowError(IntentStateError)
+
+    expect(() =>
+      service.recordPreflight(
+        intent.intentId,
+        buildPreflightRequest({ positionUsd: 9_999 }),
+        buildPreflightResult(),
+        'req-3'
+      )
+    ).toThrowError(IntentStateError)
+
+    expect(() =>
+      service.recordPreflight(
+        intent.intentId,
+        buildPreflightRequest(),
+        buildPreflightResult({ venue: 'live' }),
+        'req-4'
+      )
+    ).toThrowError(IntentStateError)
   })
 
   it('rejects policy violations', () => {
@@ -404,6 +504,38 @@ describe('ExecutionService', () => {
       status: 'filled',
       orderId: 'venue-filled-1',
     })
+  })
+
+  it('persists preflight records across service instances with the durable repository', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'blackice-preflight-records-'))
+    tempDirs.push(dir)
+    const storagePath = path.join(dir, 'execution-state.json')
+
+    const firstRepository = new FileExecutionRepository(storagePath)
+    const firstService = new ExecutionService({
+      repository: firstRepository,
+      now: () => new Date('2026-04-18T12:00:00.000Z'),
+    })
+    const { intent } = firstService.submitIntent(validIntent, 'req-1')
+    const recorded = firstService.recordPreflight(
+      intent.intentId,
+      buildPreflightRequest(),
+      buildPreflightResult(),
+      'req-2'
+    )
+
+    const secondRepository = new FileExecutionRepository(storagePath)
+    const secondService = new ExecutionService({
+      repository: secondRepository,
+      now: () => new Date('2026-04-18T12:00:01.000Z'),
+    })
+
+    expect(secondService.getLatestPreflightRecord(intent.intentId)).toMatchObject({
+      preflightId: recorded.preflightId,
+      intentId: intent.intentId,
+      policyFingerprint: recorded.policyFingerprint,
+    })
+    expect(JSON.parse(readFileSync(storagePath, 'utf8')).preflightRecords).toHaveLength(1)
   })
 
   it('reloads intents from a durable repository across service instances', () => {

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -3,6 +3,9 @@ import { getRuntimeConfig } from '../config/runtimeConfig.js'
 import type {
   ExecutionAdapter,
   ExecutionRepository,
+  PreflightRecord,
+  PreflightRequest,
+  PreflightResult,
   SignedExecutionRequest,
   SigningAdapter,
 } from './contracts.js'
@@ -13,6 +16,7 @@ import {
   mapExecutionLogToAuditEventType,
   mapExecutionLogToIntentStatus,
 } from './executionAdapter.js'
+import { buildPreflightRecord } from './preflight.js'
 import { createExecutionRepository } from './repository.js'
 import { createSigningAdapter } from './signing.js'
 import {
@@ -103,6 +107,45 @@ export class ExecutionService {
       throw new IntentNotFoundError(intentId)
     }
     return intent
+  }
+
+  listPreflightRecords(intentId: string): PreflightRecord[] {
+    this.getIntent(intentId)
+    return this.repository.listPreflightRecords(intentId)
+  }
+
+  getLatestPreflightRecord(intentId: string): PreflightRecord | null {
+    this.getIntent(intentId)
+    return this.repository.getLatestPreflightRecord(intentId)
+  }
+
+  recordPreflight(
+    intentId: string,
+    request: PreflightRequest,
+    result: PreflightResult,
+    requestId: string
+  ): PreflightRecord {
+    const intent = this.getIntent(intentId)
+    const normalizedRequest = this.normalizePreflightRequest(intent, request)
+    if (result.venue !== normalizedRequest.venue) {
+      throw new IntentStateError(
+        `Preflight result venue ${result.venue} does not match intent venue ${intent.venue}`
+      )
+    }
+    const record = buildPreflightRecord({
+      intentId,
+      recordedAt: this.now().toISOString(),
+      request: normalizedRequest,
+      result,
+    })
+
+    this.repository.appendPreflightRecord(record)
+    this.appendAuditEvent(intent, 'preflight_recorded', requestId, {
+      preflightId: record.preflightId,
+      preflightOk: record.result.ok,
+      policyFingerprint: record.policyFingerprint,
+    })
+    return record
   }
 
   submitIntent(
@@ -357,5 +400,30 @@ export class ExecutionService {
       intent.ttlSeconds === input.ttlSeconds &&
       JSON.stringify(intent.metadata) === JSON.stringify(input.metadata ?? {})
     )
+  }
+
+  private normalizePreflightRequest(
+    intent: IntentRecord,
+    request: PreflightRequest
+  ): PreflightRequest {
+    const venue = request.venue ?? intent.venue
+    if (venue !== intent.venue) {
+      throw new IntentStateError(
+        `Preflight venue ${venue} does not match intent venue ${intent.venue}`
+      )
+    }
+
+    const positionUsd = request.positionUsd ?? intent.notionalUsd
+    if (positionUsd !== intent.notionalUsd) {
+      throw new IntentStateError(
+        `Preflight position ${positionUsd} does not match intent notional ${intent.notionalUsd}`
+      )
+    }
+
+    return {
+      ...request,
+      venue,
+      positionUsd,
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a durable preflight record contract and repository storage for intent-bound preflight history
- add service methods to record, list, and fetch the latest preflight record for an intent
- add a stable policy fingerprint so later execute-gating work can compare stored preflight inputs against current config

## Scope
- contracts, repository persistence, and execution service binding only
- no route changes in this PR

## Files Touched
- `src/execution/contracts.ts`
- `src/execution/schema.ts`
- `src/execution/preflight.ts`
- `src/execution/repository.ts`
- `src/execution/service.ts`
- focused tests for each updated module

## Tests Run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/contracts.test.ts src/execution/preflight.test.ts src/execution/repository.test.ts src/execution/service.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Notes
- preflight records are intent-bound: mismatched venue, position, or result venue are rejected at the service layer
- this PR is the foundation for later intent-scoped preflight routes and execute gating cleanup
