### PR TITLE
feat: add intent-scoped preflight flow and execute gating

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -34,6 +34,7 @@ const DEFAULT_MARKET_DATA_MAX_SPREAD_BPS = 500
 const DEFAULT_EXECUTION_DEFAULT_VENUE = 'paper'
 const DEFAULT_EXECUTION_MAX_POSITION_USD = 1_000
 const DEFAULT_EXECUTION_REQUIRE_PREFLIGHT = true
+const DEFAULT_EXECUTION_PREFLIGHT_MAX_AGE_SECONDS = 300
 const DEFAULT_EXECUTION_SIGNER_KIND = 'mock'
 const DEFAULT_EXECUTION_STORAGE_KIND = 'memory'
 const DEFAULT_EXECUTION_STORAGE_PATH = ''
@@ -105,6 +106,7 @@ const YamlConfigSchema = z
         defaultVenue: z.string().trim().min(1).optional(),
         allowedVenues: z.array(z.string().trim().min(1)).optional(),
         requirePreflight: z.boolean().optional(),
+        preflightMaxAgeSeconds: z.number().int().positive().optional(),
         maxPositionUsd: z.number().positive().optional(),
         signerKind: z.string().trim().min(1).optional(),
         storageKind: z.string().trim().min(1).optional(),
@@ -172,6 +174,7 @@ const RuntimeConfigSchema = z
       defaultVenue: z.string().min(1),
       allowedVenues: z.array(z.string().min(1)).min(1),
       requirePreflight: z.boolean(),
+      preflightMaxAgeSeconds: z.number().int().positive(),
       maxPositionUsd: z.number().positive(),
       signerKind: z.string().min(1),
       storageKind: z.string().min(1),
@@ -302,6 +305,8 @@ export function getRuntimeConfig(): RuntimeConfig {
       defaultVenue,
     ],
     requirePreflight: executionYaml.requirePreflight ?? DEFAULT_EXECUTION_REQUIRE_PREFLIGHT,
+    preflightMaxAgeSeconds:
+      executionYaml.preflightMaxAgeSeconds ?? DEFAULT_EXECUTION_PREFLIGHT_MAX_AGE_SECONDS,
     maxPositionUsd: executionYaml.maxPositionUsd ?? DEFAULT_EXECUTION_MAX_POSITION_USD,
     signerKind: String(executionYaml.signerKind ?? DEFAULT_EXECUTION_SIGNER_KIND).trim(),
     storageKind: String(executionYaml.storageKind ?? DEFAULT_EXECUTION_STORAGE_KIND).trim(),

--- a/src/execution/schema.ts
+++ b/src/execution/schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import {
   CandidateDiscoveryQuerySchema,
   EnrichedCandidateRecordSchema,
-  PreflightRequestSchema,
+  PreflightRecordSchema,
   PreflightResultSchema,
 } from './contracts.js'
 
@@ -115,16 +115,12 @@ export const IntentActionResponseSchema = z.object({
   intent: IntentRecordSchema,
 })
 
-export const ExecuteIntentRequestSchema = z
-  .object({
-    preflight: PreflightRequestSchema.optional(),
-  })
-  .default({})
+export const ExecuteIntentRequestSchema = z.object({}).default({})
 
 export const ExecuteIntentResponseSchema = z.object({
   ok: z.literal(true),
   intent: IntentRecordSchema,
-  preflight: PreflightResultSchema.optional(),
+  preflightRecord: PreflightRecordSchema.optional(),
 })
 
 export const ListIntentsResponseSchema = z.object({
@@ -142,6 +138,11 @@ export const ListCandidatesResponseSchema = z.object({
 export const PreflightActionResponseSchema = z.object({
   ok: z.literal(true),
   preflight: PreflightResultSchema,
+})
+
+export const IntentPreflightResponseSchema = z.object({
+  ok: z.literal(true),
+  preflightRecord: PreflightRecordSchema,
 })
 
 export type SubmitIntentRequest = z.input<typeof SubmitIntentRequestSchema>

--- a/src/execution/service.test.ts
+++ b/src/execution/service.test.ts
@@ -154,6 +154,52 @@ describe('ExecutionService', () => {
     expect(service.getIntent(intent.intentId).auditTrail.at(-1)?.type).toBe('preflight_recorded')
   })
 
+  it('returns the latest successful preflight record for execution gating', () => {
+    const { service } = buildService()
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    const record = service.recordPreflight(
+      intent.intentId,
+      buildPreflightRequest(),
+      buildPreflightResult(),
+      'req-2'
+    )
+
+    expect(service.getExecutionPreflightRecord(intent.intentId)?.preflightId).toBe(
+      record.preflightId
+    )
+  })
+
+  it('rejects execute-time use of failed or stale preflight records', () => {
+    const { service, advanceTime } = buildService()
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+
+    service.recordPreflight(
+      intent.intentId,
+      buildPreflightRequest(),
+      buildPreflightResult({ ok: false }),
+      'req-2'
+    )
+    expect(() => service.getExecutionPreflightRecord(intent.intentId)).toThrowError(
+      ExecutionPolicyError
+    )
+
+    const { intent: secondIntent } = service.submitIntent(
+      { ...validIntent, idempotencyKey: 'idem-2', market: 'ETH-USD' },
+      'req-3'
+    )
+    service.recordPreflight(
+      secondIntent.intentId,
+      buildPreflightRequest(),
+      buildPreflightResult(),
+      'req-4'
+    )
+    advanceTime(301_000)
+
+    expect(() => service.getExecutionPreflightRecord(secondIntent.intentId)).toThrowError(
+      ExecutionPolicyError
+    )
+  })
+
   it('rejects preflight records whose venue or position do not match the intent', () => {
     const { service } = buildService()
 

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -16,7 +16,7 @@ import {
   mapExecutionLogToAuditEventType,
   mapExecutionLogToIntentStatus,
 } from './executionAdapter.js'
-import { buildPreflightRecord } from './preflight.js'
+import { buildPreflightRecord, computePreflightPolicyFingerprint } from './preflight.js'
 import { createExecutionRepository } from './repository.js'
 import { createSigningAdapter } from './signing.js'
 import {
@@ -117,6 +117,47 @@ export class ExecutionService {
   getLatestPreflightRecord(intentId: string): PreflightRecord | null {
     this.getIntent(intentId)
     return this.repository.getLatestPreflightRecord(intentId)
+  }
+
+  getExecutionPreflightRecord(intentId: string): PreflightRecord | null {
+    const intent = this.getIntent(intentId)
+    const record = this.repository.getLatestPreflightRecord(intentId)
+    if (!record) {
+      return null
+    }
+
+    const normalizedRequest = this.normalizePreflightRequest(intent, record.request)
+    if (!record.result.ok) {
+      throw new ExecutionPolicyError(
+        `Latest preflight for intent ${intentId} did not pass`,
+        'preflight_failed'
+      )
+    }
+
+    if (record.result.venue !== normalizedRequest.venue) {
+      throw new ExecutionPolicyError(
+        `Latest preflight for intent ${intentId} does not match the current venue`,
+        'preflight_mismatch'
+      )
+    }
+
+    const expectedFingerprint = computePreflightPolicyFingerprint(normalizedRequest)
+    if (record.policyFingerprint !== expectedFingerprint) {
+      throw new ExecutionPolicyError(
+        `Latest preflight for intent ${intentId} no longer matches current policy`,
+        'preflight_stale'
+      )
+    }
+
+    const maxAgeMs = getRuntimeConfig().execution.preflightMaxAgeSeconds * 1000
+    if (Date.parse(record.recordedAt) + maxAgeMs < this.now().getTime()) {
+      throw new ExecutionPolicyError(
+        `Latest preflight for intent ${intentId} is stale`,
+        'preflight_stale'
+      )
+    }
+
+    return record
   }
 
   recordPreflight(

--- a/src/routes.integration.test.ts
+++ b/src/routes.integration.test.ts
@@ -317,20 +317,19 @@ describe('integration routes', () => {
     const intentId = submit.body.intent.intentId
 
     const confirm = await request(app).post(`/v1/intents/${intentId}/confirm`).send({})
-    const execute = await request(app)
-      .post(`/v1/intents/${intentId}/execute`)
-      .send({
-        preflight: {
-          candidate: buildEnrichedCandidate(),
-        },
-      })
+    const preflight = await request(app).post(`/v1/intents/${intentId}/preflight`).send({
+      candidate: buildEnrichedCandidate(),
+    })
+    const execute = await request(app).post(`/v1/intents/${intentId}/execute`).send({})
 
     expect(confirm.status).toBe(200)
     expect(confirm.body.intent.status).toBe('confirmed')
+    expect(preflight.status).toBe(200)
+    expect(preflight.body.preflightRecord.result.ok).toBe(true)
     expect(execute.status).toBe(200)
     expect(execute.body.intent.status).toBe('executed')
     expect(execute.body.intent.orders).toHaveLength(1)
-    expect(execute.body.preflight.ok).toBe(true)
+    expect(execute.body.preflightRecord.result.ok).toBe(true)
   })
 
   it('POST /v1/intents rejects disallowed venues', async () => {
@@ -401,11 +400,11 @@ describe('integration routes', () => {
     expect(res.body.preflight.venue).toBe('paper')
   })
 
-  it('POST /v1/intents/:intentId/execute blocks execution when preflight is missing or failed', async () => {
+  it('POST /v1/intents/:intentId/preflight records a persisted preflight for the intent', async () => {
     const { createApp } = await import('./app.js')
     const app = createApp(1, {
       preflightEvaluator: {
-        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(false)),
+        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(true)),
       },
     })
 
@@ -421,22 +420,55 @@ describe('integration routes', () => {
     })
     const intentId = submit.body.intent.intentId
 
+    const preflight = await request(app).post(`/v1/intents/${intentId}/preflight`).send({
+      candidate: buildEnrichedCandidate(),
+      venue: 'kraken',
+      positionUsd: 1,
+    })
+
+    expect(preflight.status).toBe(200)
+    expect(preflight.body.preflightRecord.intentId).toBe(intentId)
+    expect(preflight.body.preflightRecord.request.venue).toBe('paper')
+    expect(preflight.body.preflightRecord.request.positionUsd).toBe(250)
+    expect(preflight.body.preflightRecord.result.ok).toBe(true)
+  })
+
+  it('POST /v1/intents/:intentId/execute blocks execution when persisted preflight is missing or failed', async () => {
+    const { createApp } = await import('./app.js')
+    const app = createApp(1, {
+      preflightEvaluator: {
+        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(false)),
+      },
+    })
+
+    const submit = await request(app).post('/v1/intents').send({
+      idempotencyKey: 'idem-http-6',
+      accountId: 'acct-primary',
+      market: 'DOGE-USD',
+      venue: 'paper',
+      side: 'buy',
+      quantity: 5,
+      notionalUsd: 250,
+      ttlSeconds: 300,
+    })
+    const intentId = submit.body.intent.intentId
+
     await request(app).post(`/v1/intents/${intentId}/confirm`).send({})
 
     const missingPreflight = await request(app).post(`/v1/intents/${intentId}/execute`).send({})
-    const failedPreflight = await request(app)
+    const failedPreflight = await request(app).post(`/v1/intents/${intentId}/preflight`).send({
+      candidate: buildEnrichedCandidate(),
+    })
+    const executeAfterFailedPreflight = await request(app)
       .post(`/v1/intents/${intentId}/execute`)
-      .send({
-        preflight: {
-          candidate: buildEnrichedCandidate(),
-        },
-      })
+      .send({})
 
     expect(missingPreflight.status).toBe(422)
     expect(missingPreflight.body.code).toBe('preflight_required')
-    expect(failedPreflight.status).toBe(422)
-    expect(failedPreflight.body.code).toBe('preflight_failed')
-    expect(failedPreflight.body.preflight.ok).toBe(false)
+    expect(failedPreflight.status).toBe(200)
+    expect(failedPreflight.body.preflightRecord.result.ok).toBe(false)
+    expect(executeAfterFailedPreflight.status).toBe(422)
+    expect(executeAfterFailedPreflight.body.code).toBe('preflight_failed')
   })
 
   it('POST /analyze/logs returns validation error for bad payload', async () => {

--- a/src/routes/intents.ts
+++ b/src/routes/intents.ts
@@ -19,6 +19,7 @@ import {
   IntentStatusSchema,
   ExecuteIntentRequestSchema,
   ExecuteIntentResponseSchema,
+  IntentPreflightResponseSchema,
   ListCandidatesResponseSchema,
   ListCandidatesRequestSchema,
   ListIntentsResponseSchema,
@@ -101,6 +102,44 @@ export function registerIntentRoutes(
     }
   })
 
+  app.post('/v1/intents/:intentId/preflight', async (req: Request, res: Response) => {
+    const requestId = getRequestId(res)
+    const parsed = parseBodyOrRespond(PreflightRequestSchema, req.body, res)
+    if (!parsed) {
+      return
+    }
+
+    try {
+      const intent = executionService.getIntent(req.params.intentId)
+      const preflightRequest = {
+        ...parsed,
+        venue: intent.venue,
+        positionUsd: intent.notionalUsd,
+      }
+      const preflight = await preflightEvaluator.evaluate(preflightRequest)
+      const preflightRecord = executionService.recordPreflight(
+        intent.intentId,
+        preflightRequest,
+        preflight,
+        requestId
+      )
+      log.info('intent_preflight_recorded', {
+        request_id: requestId,
+        intent_id: intent.intentId,
+        venue: preflightRecord.result.venue,
+        ok: preflightRecord.result.ok,
+      })
+      res.status(200).json(
+        IntentPreflightResponseSchema.parse({
+          ok: true,
+          preflightRecord,
+        })
+      )
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
   app.post('/v1/intents', (req: Request, res: Response) => {
     const requestId = getRequestId(res)
     const parsed = parseBodyOrRespond(SubmitIntentRequestSchema, req.body, res)
@@ -173,45 +212,26 @@ export function registerIntentRoutes(
   app.post('/v1/intents/:intentId/execute', async (req: Request, res: Response) => {
     try {
       const requestId = getRequestId(res)
-      const parsed = parseBodyOrRespond(ExecuteIntentRequestSchema, req.body ?? {}, res)
-      if (!parsed) {
+      if (!parseBodyOrRespond(ExecuteIntentRequestSchema, req.body ?? {}, res)) {
         return
       }
 
-      const intent = executionService.getIntent(req.params.intentId)
-      let preflight = undefined
-
-      if (parsed.preflight) {
-        preflight = await preflightEvaluator.evaluate({
-          ...parsed.preflight,
-          venue: intent.venue,
-          positionUsd: intent.notionalUsd,
-        })
-      }
-
-      if (requirePreflightExecution() && !preflight) {
+      const preflightRecord = requirePreflightExecution()
+        ? executionService.getExecutionPreflightRecord(req.params.intentId)
+        : null
+      if (requirePreflightExecution() && !preflightRecord) {
         res.status(422).json({
           error: 'Preflight is required before execution',
           code: 'preflight_required',
         })
         return
       }
-
-      if (preflight && !preflight.ok) {
-        res.status(422).json({
-          error: 'Preflight failed',
-          code: 'preflight_failed',
-          preflight,
-        })
-        return
-      }
-
       const executedIntent = await executionService.executeIntent(req.params.intentId, requestId)
       res.status(200).json(
         ExecuteIntentResponseSchema.parse({
           ok: true,
           intent: executedIntent,
-          preflight,
+          preflightRecord: preflightRecord ?? undefined,
         })
       )
     } catch (error) {

--- a/src/runtimeConfig.test.ts
+++ b/src/runtimeConfig.test.ts
@@ -67,6 +67,7 @@ execution:
     - paper
     - sandbox
   requirePreflight: false
+  preflightMaxAgeSeconds: 120
   maxPositionUsd: 2500
   signerKind: backend
   storageKind: sqlite
@@ -97,6 +98,7 @@ execution:
         defaultVenue: 'paper',
         allowedVenues: ['paper', 'sandbox'],
         requirePreflight: false,
+        preflightMaxAgeSeconds: 120,
         maxPositionUsd: 2500,
         signerKind: 'backend',
         storageKind: 'sqlite',
@@ -129,6 +131,7 @@ server:
         defaultVenue: 'paper',
         allowedVenues: ['paper'],
         requirePreflight: true,
+        preflightMaxAgeSeconds: 300,
         maxPositionUsd: 1000,
         signerKind: 'mock',
         storageKind: 'memory',


### PR DESCRIPTION
## Summary
- add `POST /v1/intents/:intentId/preflight` as the canonical persisted preflight route
- gate `POST /v1/intents/:intentId/execute` on the latest stored preflight record instead of caller-supplied preflight input
- add config-backed preflight freshness validation before execution

## Dependency
- built on merged persisted preflight storage from #164

## Files Touched
- `src/routes/intents.ts`
- `src/execution/service.ts`
- `src/execution/schema.ts`
- `src/config/runtimeConfig.ts`
- focused route/service/config tests

## Tests Run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/runtimeConfig.test.ts src/execution/service.test.ts src/routes.integration.test.ts src/execution/contracts.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out Of Scope
- execution refresh/reconciliation
- audit/read routes for preflight or execution logs
- CI workflow trigger fixes
- new discovery or execution strategy behavior

## Notes
- the repo hook path in this worktree could not resolve `pnpm exec biome`, so the touched files were formatted directly with the pinned repo biome binary before commit and push.
