### PR TITLE
feat: add execution refresh and reconciliation flow

### DIFF
--- a/src/execution/contracts.ts
+++ b/src/execution/contracts.ts
@@ -143,6 +143,7 @@ export type SigningAdapter = {
 export type ExecutionAdapter = {
   placeOrder(request: SignedExecutionRequest): Promise<ExecutionLogRecord>
   cancelOrder(orderId: string, requestId: string): Promise<ExecutionLogRecord>
+  getOrderStatus(orderId: string, requestId: string): Promise<ExecutionLogRecord | null>
 }
 
 export type ExecutionRepository = {
@@ -155,5 +156,6 @@ export type ExecutionRepository = {
   listPreflightRecords(intentId: string): PreflightRecord[]
   getLatestPreflightRecord(intentId: string): PreflightRecord | null
   appendPreflightRecord(record: PreflightRecord): void
+  listExecutionLogs(intentId: string): ExecutionLogRecord[]
   appendExecutionLog(record: ExecutionLogRecord): void
 }

--- a/src/execution/executionAdapter.test.ts
+++ b/src/execution/executionAdapter.test.ts
@@ -6,6 +6,7 @@ import {
   mapExecutionLogToIntentStatus,
   mapExecutionLogToOrderStatus,
   PaperExecutionAdapter,
+  updateOrderRecordFromExecutionLog,
 } from './executionAdapter.js'
 import type { ExecutionLogRecord } from './contracts.js'
 import type { IntentRecord } from './schema.js'
@@ -122,5 +123,44 @@ describe('executionAdapter', () => {
     expect(placed.orderId).toBe('paper-req-4')
     expect(cancelled.status).toBe('cancelled')
     expect(cancelled.orderId).toBe('venue-order-2')
+    await expect(adapter.getOrderStatus('venue-order-3', 'req-6')).resolves.toMatchObject({
+      status: 'filled',
+      orderId: 'venue-order-3',
+    })
+  })
+
+  it('updates existing order records from refreshed execution logs', () => {
+    const order = buildOrderRecordFromExecutionLog({
+      intent: baseIntent,
+      executionLog: {
+        logId: 'log-pending',
+        intentId: baseIntent.intentId,
+        venue: baseIntent.venue,
+        status: 'accepted',
+        recordedAt: '2026-04-22T00:01:00.000Z',
+        orderId: 'venue-order-4',
+        requestId: 'req-7',
+        preflightOk: true,
+        details: {},
+      },
+    })
+
+    const refreshed = updateOrderRecordFromExecutionLog({
+      order,
+      executionLog: {
+        logId: 'log-filled',
+        intentId: baseIntent.intentId,
+        venue: baseIntent.venue,
+        status: 'filled',
+        recordedAt: '2026-04-22T00:02:00.000Z',
+        orderId: 'venue-order-4',
+        requestId: 'req-8',
+        preflightOk: true,
+        details: {},
+      },
+    })
+
+    expect(refreshed.status).toBe('filled')
+    expect(refreshed.updatedAt).toBe('2026-04-22T00:02:00.000Z')
   })
 })

--- a/src/execution/executionAdapter.ts
+++ b/src/execution/executionAdapter.ts
@@ -55,6 +55,20 @@ export class PaperExecutionAdapter implements ExecutionAdapter {
       details: {},
     })
   }
+
+  async getOrderStatus(orderId: string, requestId: string): Promise<ExecutionLogRecord | null> {
+    return ExecutionLogRecordSchema.parse({
+      logId: randomUUID(),
+      intentId: orderId,
+      venue: 'paper',
+      status: 'filled',
+      recordedAt: new Date().toISOString(),
+      orderId,
+      requestId,
+      preflightOk: true,
+      details: {},
+    })
+  }
 }
 
 export function createExecutionAdapter(options: { venue?: string } = {}): ExecutionAdapter {
@@ -160,6 +174,22 @@ export function buildOrderRecordFromExecutionLog(input: {
     updatedAt: recordedAt,
     externalOrderId: input.executionLog.orderId,
     failureReason,
+  })
+}
+
+export function updateOrderRecordFromExecutionLog(input: {
+  order: OrderRecord
+  executionLog: ExecutionLogRecord
+  recordedAt?: string
+}): OrderRecord {
+  const recordedAt = input.recordedAt ?? input.executionLog.recordedAt
+
+  return OrderRecordSchema.parse({
+    ...input.order,
+    status: mapExecutionLogToOrderStatus(input.executionLog.status),
+    updatedAt: recordedAt,
+    externalOrderId: input.executionLog.orderId ?? input.order.externalOrderId,
+    failureReason: extractFailureReason(input.executionLog),
   })
 }
 

--- a/src/execution/repository.test.ts
+++ b/src/execution/repository.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { IntentRecord } from './schema.js'
-import type { PreflightRecord } from './contracts.js'
+import type { ExecutionLogRecord, PreflightRecord } from './contracts.js'
 import { FileExecutionRepository, InMemoryExecutionRepository } from './repository.js'
 
 const tempDirs: string[] = []
@@ -82,6 +82,21 @@ function buildPreflightRecord(overrides: Partial<PreflightRecord> = {}): Preflig
   }
 }
 
+function buildExecutionLogRecord(overrides: Partial<ExecutionLogRecord> = {}): ExecutionLogRecord {
+  return {
+    logId: 'log-1',
+    intentId: 'intent-1',
+    venue: 'paper',
+    status: 'placed',
+    recordedAt: '2026-04-21T00:02:00.000Z',
+    orderId: 'venue-order-1',
+    requestId: 'req-1',
+    preflightOk: true,
+    details: {},
+    ...overrides,
+  }
+}
+
 afterEach(() => {
   while (tempDirs.length > 0) {
     rmSync(tempDirs.pop() as string, { recursive: true, force: true })
@@ -93,14 +108,17 @@ describe('execution repositories', () => {
     const repository = new InMemoryExecutionRepository()
     const intent = buildIntent()
     const preflightRecord = buildPreflightRecord()
+    const executionLog = buildExecutionLogRecord()
 
     repository.saveIntent(intent)
     repository.saveIdempotencyKey(intent.idempotencyKey, intent.intentId)
     repository.appendPreflightRecord(preflightRecord)
+    repository.appendExecutionLog(executionLog)
 
     expect(repository.getIntent(intent.intentId)).toMatchObject(intent)
     expect(repository.getIntentIdByIdempotencyKey(intent.idempotencyKey)).toBe(intent.intentId)
     expect(repository.getLatestPreflightRecord(intent.intentId)).toMatchObject(preflightRecord)
+    expect(repository.listExecutionLogs(intent.intentId)).toMatchObject([executionLog])
   })
 
   it('persists intents to disk across repository instances', () => {
@@ -108,10 +126,12 @@ describe('execution repositories', () => {
     const firstRepository = new FileExecutionRepository(storagePath)
     const intent = buildIntent()
     const preflightRecord = buildPreflightRecord()
+    const executionLog = buildExecutionLogRecord()
 
     firstRepository.saveIntent(intent)
     firstRepository.saveIdempotencyKey(intent.idempotencyKey, intent.intentId)
     firstRepository.appendPreflightRecord(preflightRecord)
+    firstRepository.appendExecutionLog(executionLog)
 
     const secondRepository = new FileExecutionRepository(storagePath)
     expect(secondRepository.getIntent(intent.intentId)).toMatchObject(intent)
@@ -122,9 +142,11 @@ describe('execution repositories', () => {
     expect(secondRepository.getLatestPreflightRecord(intent.intentId)).toMatchObject(
       preflightRecord
     )
+    expect(secondRepository.listExecutionLogs(intent.intentId)).toMatchObject([executionLog])
 
     const persisted = JSON.parse(readFileSync(storagePath, 'utf8'))
     expect(persisted.idempotencyKeys[intent.idempotencyKey]).toBe(intent.intentId)
     expect(persisted.preflightRecords).toHaveLength(1)
+    expect(persisted.executionLogs).toHaveLength(1)
   })
 })

--- a/src/execution/repository.ts
+++ b/src/execution/repository.ts
@@ -113,6 +113,12 @@ export class InMemoryExecutionRepository implements ExecutionRepository {
     this.state.preflightRecords.push(PreflightRecordSchema.parse(structuredClone(record)))
   }
 
+  listExecutionLogs(intentId: string): ExecutionLogRecord[] {
+    return this.state.executionLogs
+      .filter((record) => record.intentId === intentId)
+      .map((record) => structuredClone(record))
+  }
+
   appendExecutionLog(record: ExecutionLogRecord): void {
     this.state.executionLogs.push(structuredClone(record))
   }
@@ -179,6 +185,12 @@ export class FileExecutionRepository implements ExecutionRepository {
     const state = this.readState()
     state.preflightRecords.push(PreflightRecordSchema.parse(structuredClone(record)))
     this.writeState(state)
+  }
+
+  listExecutionLogs(intentId: string): ExecutionLogRecord[] {
+    return this.readState()
+      .executionLogs.filter((record) => record.intentId === intentId)
+      .map((record) => structuredClone(record))
   }
 
   appendExecutionLog(record: ExecutionLogRecord): void {

--- a/src/execution/schema.ts
+++ b/src/execution/schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import {
   CandidateDiscoveryQuerySchema,
   EnrichedCandidateRecordSchema,
+  ExecutionLogRecordSchema,
   PreflightRecordSchema,
   PreflightResultSchema,
 } from './contracts.js'
@@ -121,6 +122,12 @@ export const ExecuteIntentResponseSchema = z.object({
   ok: z.literal(true),
   intent: IntentRecordSchema,
   preflightRecord: PreflightRecordSchema.optional(),
+})
+
+export const IntentRefreshResponseSchema = z.object({
+  ok: z.literal(true),
+  intent: IntentRecordSchema,
+  executionLog: ExecutionLogRecordSchema.optional(),
 })
 
 export const ListIntentsResponseSchema = z.object({

--- a/src/execution/service.test.ts
+++ b/src/execution/service.test.ts
@@ -297,6 +297,9 @@ describe('ExecutionService', () => {
         async cancelOrder() {
           return buildExecutionLog('cancelled')
         },
+        async getOrderStatus() {
+          return null
+        },
       },
     })
 
@@ -327,6 +330,9 @@ describe('ExecutionService', () => {
         },
         async cancelOrder() {
           return buildExecutionLog('cancelled')
+        },
+        async getOrderStatus() {
+          return null
         },
       },
     })
@@ -361,6 +367,9 @@ describe('ExecutionService', () => {
         async cancelOrder() {
           return buildExecutionLog('cancelled')
         },
+        async getOrderStatus() {
+          return null
+        },
       },
     })
 
@@ -375,6 +384,77 @@ describe('ExecutionService', () => {
       externalOrderId: 'venue-placed-1',
     })
     expect(result.auditTrail.at(-1)?.type).toBe('execution_pending')
+  })
+
+  it('refreshes a pending intent into executed when venue status advances', async () => {
+    const service = new ExecutionService({
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
+        async placeOrder() {
+          return buildExecutionLog('accepted', {
+            orderId: 'venue-refresh-1',
+          })
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
+        },
+        async getOrderStatus(orderId) {
+          return buildExecutionLog('filled', {
+            orderId,
+            recordedAt: '2026-04-18T12:00:02.000Z',
+          })
+        },
+      },
+    })
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+    await service.executeIntent(intent.intentId, 'req-3')
+
+    const refreshed = await service.refreshIntent(intent.intentId, 'req-4')
+
+    expect(refreshed.executionLog?.status).toBe('filled')
+    expect(refreshed.intent.status).toBe('executed')
+    expect(refreshed.intent.orders.at(-1)).toMatchObject({
+      status: 'filled',
+      externalOrderId: 'venue-refresh-1',
+    })
+  })
+
+  it('returns the current intent when refresh has no new venue state', async () => {
+    const service = new ExecutionService({
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
+        async placeOrder() {
+          return buildExecutionLog('accepted', {
+            orderId: 'venue-refresh-2',
+          })
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
+        },
+        async getOrderStatus() {
+          return null
+        },
+      },
+    })
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+    await service.executeIntent(intent.intentId, 'req-3')
+
+    const refreshed = await service.refreshIntent(intent.intentId, 'req-4')
+
+    expect(refreshed.executionLog).toBeUndefined()
+    expect(refreshed.intent.status).toBe('execution_pending')
   })
 
   it('keeps the intent confirmed when the venue returns a cancelled order', async () => {
@@ -392,6 +472,9 @@ describe('ExecutionService', () => {
         },
         async cancelOrder() {
           return buildExecutionLog('cancelled')
+        },
+        async getOrderStatus() {
+          return null
         },
       },
     })
@@ -428,6 +511,9 @@ describe('ExecutionService', () => {
         },
         async cancelOrder() {
           return buildExecutionLog('cancelled')
+        },
+        async getOrderStatus() {
+          return null
         },
       },
     })
@@ -525,6 +611,9 @@ describe('ExecutionService', () => {
         },
         async cancelOrder() {
           return buildExecutionLog('cancelled')
+        },
+        async getOrderStatus() {
+          return null
         },
       },
     })

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { getRuntimeConfig } from '../config/runtimeConfig.js'
 import type {
   ExecutionAdapter,
+  ExecutionLogRecord,
   ExecutionRepository,
   PreflightRecord,
   PreflightRequest,
@@ -15,6 +16,8 @@ import {
   createExecutionAdapter,
   mapExecutionLogToAuditEventType,
   mapExecutionLogToIntentStatus,
+  mapExecutionLogToOrderStatus,
+  updateOrderRecordFromExecutionLog,
 } from './executionAdapter.js'
 import { buildPreflightRecord, computePreflightPolicyFingerprint } from './preflight.js'
 import { createExecutionRepository } from './repository.js'
@@ -314,34 +317,7 @@ export class ExecutionService {
 
     try {
       const executionLog = await this.executionAdapter.placeOrder(signedRequest)
-      this.repository.appendExecutionLog(executionLog)
-
-      const nowIso = executionLog.recordedAt
-      const order = buildOrderRecordFromExecutionLog({
-        intent,
-        executionLog,
-        recordedAt: nowIso,
-      })
-
-      intent.orders.push(order)
-      intent.status = mapExecutionLogToIntentStatus(executionLog.status)
-      intent.updatedAt = nowIso
-
-      if (intent.status === 'executed') {
-        intent.executedAt = nowIso
-      }
-
-      this.repository.saveIntent(intent)
-      this.appendAuditEvent(
-        intent,
-        mapExecutionLogToAuditEventType(executionLog.status),
-        requestId,
-        {
-          externalOrderId: executionLog.orderId,
-          executionStatus: executionLog.status,
-          logId: executionLog.logId,
-        }
-      )
+      this.applyExecutionLog(intent, executionLog, requestId, 'append')
       return intent
     } catch (error) {
       const nowIso = this.now().toISOString()
@@ -353,6 +329,42 @@ export class ExecutionService {
       })
       throw error
     }
+  }
+
+  async refreshIntent(
+    intentId: string,
+    requestId: string
+  ): Promise<{ intent: IntentRecord; executionLog?: ExecutionLogRecord }> {
+    const intent = this.getIntent(intentId)
+    if (intent.status !== 'execution_pending') {
+      return { intent }
+    }
+
+    const latestOrder = intent.orders.at(-1)
+    if (!latestOrder?.externalOrderId) {
+      return { intent }
+    }
+
+    const executionLog = await this.executionAdapter.getOrderStatus(
+      latestOrder.externalOrderId,
+      requestId
+    )
+    if (!executionLog) {
+      return { intent }
+    }
+
+    const normalizedExecutionLog: ExecutionLogRecord = {
+      ...executionLog,
+      intentId: intent.intentId,
+      venue: intent.venue,
+    }
+
+    if (mapExecutionLogToOrderStatus(normalizedExecutionLog.status) === latestOrder.status) {
+      return { intent }
+    }
+
+    this.applyExecutionLog(intent, normalizedExecutionLog, requestId, 'refresh')
+    return { intent, executionLog: normalizedExecutionLog }
   }
 
   cancelIntent(intentId: string, requestId: string): IntentRecord {
@@ -466,5 +478,44 @@ export class ExecutionService {
       venue,
       positionUsd,
     }
+  }
+
+  private applyExecutionLog(
+    intent: IntentRecord,
+    executionLog: ExecutionLogRecord,
+    requestId: string,
+    mode: 'append' | 'refresh'
+  ): void {
+    this.repository.appendExecutionLog(executionLog)
+
+    const nowIso = executionLog.recordedAt
+    if (mode === 'append') {
+      intent.orders.push(
+        buildOrderRecordFromExecutionLog({
+          intent,
+          executionLog,
+          recordedAt: nowIso,
+        })
+      )
+    } else if (intent.orders.length > 0) {
+      intent.orders[intent.orders.length - 1] = updateOrderRecordFromExecutionLog({
+        order: intent.orders[intent.orders.length - 1],
+        executionLog,
+        recordedAt: nowIso,
+      })
+    }
+
+    intent.status = mapExecutionLogToIntentStatus(executionLog.status)
+    intent.updatedAt = nowIso
+    if (intent.status === 'executed') {
+      intent.executedAt = nowIso
+    }
+
+    this.repository.saveIntent(intent)
+    this.appendAuditEvent(intent, mapExecutionLogToAuditEventType(executionLog.status), requestId, {
+      externalOrderId: executionLog.orderId,
+      executionStatus: executionLog.status,
+      logId: executionLog.logId,
+    })
   }
 }

--- a/src/routes.integration.test.ts
+++ b/src/routes.integration.test.ts
@@ -471,6 +471,94 @@ describe('integration routes', () => {
     expect(executeAfterFailedPreflight.body.code).toBe('preflight_failed')
   })
 
+  it('POST /v1/intents/:intentId/refresh returns updated intent state when venue status advances', async () => {
+    const service = new (await import('./execution/service.js')).ExecutionService({
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return {
+            ...request,
+            signerRef: 'mock:paper',
+            signature: `sig:${request.requestId}`,
+          }
+        },
+      },
+      executionAdapter: {
+        async placeOrder() {
+          return {
+            logId: 'log-placed',
+            intentId: 'intent-refresh-http',
+            venue: 'paper',
+            status: 'accepted' as const,
+            recordedAt: '2026-04-23T00:02:00.000Z',
+            orderId: 'venue-refresh-http-1',
+            requestId: 'req-execute',
+            preflightOk: true,
+            details: {},
+          }
+        },
+        async cancelOrder() {
+          return {
+            logId: 'log-cancelled',
+            intentId: 'intent-refresh-http',
+            venue: 'paper',
+            status: 'cancelled' as const,
+            recordedAt: '2026-04-23T00:04:00.000Z',
+            orderId: 'venue-refresh-http-1',
+            requestId: 'req-cancel',
+            preflightOk: true,
+            details: {},
+          }
+        },
+        async getOrderStatus(orderId) {
+          return {
+            logId: 'log-filled',
+            intentId: 'intent-refresh-http',
+            venue: 'paper',
+            status: 'filled' as const,
+            recordedAt: '2026-04-23T00:03:00.000Z',
+            orderId,
+            requestId: 'req-refresh',
+            preflightOk: true,
+            details: {},
+          }
+        },
+      },
+    })
+    const { createApp } = await import('./app.js')
+    const app = createApp(1, {
+      executionService: service,
+      preflightEvaluator: {
+        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(true)),
+      },
+    })
+
+    const submit = await request(app).post('/v1/intents').send({
+      intentId: 'intent-refresh-http',
+      idempotencyKey: 'idem-http-7',
+      accountId: 'acct-primary',
+      market: 'SOL-USD',
+      venue: 'paper',
+      side: 'buy',
+      quantity: 10,
+      notionalUsd: 1500,
+      ttlSeconds: 300,
+    })
+    const intentId = submit.body.intent.intentId
+
+    await request(app).post(`/v1/intents/${intentId}/confirm`).send({})
+    await request(app).post(`/v1/intents/${intentId}/preflight`).send({
+      candidate: buildEnrichedCandidate(),
+    })
+    await request(app).post(`/v1/intents/${intentId}/execute`).send({})
+
+    const refresh = await request(app).post(`/v1/intents/${intentId}/refresh`).send({})
+
+    expect(refresh.status).toBe(200)
+    expect(refresh.body.executionLog.status).toBe('filled')
+    expect(refresh.body.intent.status).toBe('executed')
+    expect(refresh.body.intent.orders.at(-1).status).toBe('filled')
+  })
+
   it('POST /analyze/logs returns validation error for bad payload', async () => {
     const { createApp } = await import('./app.js')
     const app = createApp(1)

--- a/src/routes/intents.ts
+++ b/src/routes/intents.ts
@@ -19,6 +19,7 @@ import {
   IntentStatusSchema,
   ExecuteIntentRequestSchema,
   ExecuteIntentResponseSchema,
+  IntentRefreshResponseSchema,
   IntentPreflightResponseSchema,
   ListCandidatesResponseSchema,
   ListCandidatesRequestSchema,
@@ -244,6 +245,22 @@ export function registerIntentRoutes(
       const requestId = getRequestId(res)
       const intent = executionService.cancelIntent(req.params.intentId, requestId)
       res.status(200).json(IntentActionResponseSchema.parse({ ok: true, intent }))
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
+  app.post('/v1/intents/:intentId/refresh', async (req: Request, res: Response) => {
+    try {
+      const requestId = getRequestId(res)
+      const result = await executionService.refreshIntent(req.params.intentId, requestId)
+      res.status(200).json(
+        IntentRefreshResponseSchema.parse({
+          ok: true,
+          intent: result.intent,
+          executionLog: result.executionLog,
+        })
+      )
     } catch (error) {
       respondExecutionError(res, error)
     }


### PR DESCRIPTION
## Summary
- add execution-adapter read support for external order status refresh
- add `ExecutionService.refreshIntent(...)` to reconcile pending orders into the existing lifecycle
- add `POST /v1/intents/:intentId/refresh` and persist refreshed execution logs for later history reads

## Dependency
- built on merged intent-scoped preflight gating from #165

## Files Touched
- `src/execution/contracts.ts`
- `src/execution/executionAdapter.ts`
- `src/execution/repository.ts`
- `src/execution/service.ts`
- `src/routes/intents.ts`
- focused execution and route tests

## Tests Run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/executionAdapter.test.ts src/execution/service.test.ts src/routes.integration.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out Of Scope
- audit/read history routes
- background polling or scheduled reconciliation
- CI workflow trigger fixes
- new execution venues or strategy changes
