### PR TITLE
feat: expose intent preflight and execution history

### DIFF
--- a/src/execution/schema.ts
+++ b/src/execution/schema.ts
@@ -130,6 +130,16 @@ export const IntentRefreshResponseSchema = z.object({
   executionLog: ExecutionLogRecordSchema.optional(),
 })
 
+export const IntentPreflightHistoryResponseSchema = z.object({
+  ok: z.literal(true),
+  preflightRecords: z.array(PreflightRecordSchema),
+})
+
+export const IntentExecutionLogsResponseSchema = z.object({
+  ok: z.literal(true),
+  executionLogs: z.array(ExecutionLogRecordSchema),
+})
+
 export const ListIntentsResponseSchema = z.object({
   ok: z.literal(true),
   intents: z.array(IntentRecordSchema),

--- a/src/execution/service.test.ts
+++ b/src/execution/service.test.ts
@@ -154,6 +154,41 @@ describe('ExecutionService', () => {
     expect(service.getIntent(intent.intentId).auditTrail.at(-1)?.type).toBe('preflight_recorded')
   })
 
+  it('lists persisted execution logs for an intent', async () => {
+    const service = new ExecutionService({
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return buildSignedRequest(request)
+        },
+      },
+      executionAdapter: {
+        async placeOrder() {
+          return buildExecutionLog('filled', {
+            orderId: 'venue-log-1',
+          })
+        },
+        async cancelOrder() {
+          return buildExecutionLog('cancelled')
+        },
+        async getOrderStatus() {
+          return null
+        },
+      },
+    })
+
+    const { intent } = service.submitIntent(validIntent, 'req-1')
+    service.confirmIntent(intent.intentId, 'req-2')
+    await service.executeIntent(intent.intentId, 'req-3')
+
+    expect(service.listExecutionLogs(intent.intentId)).toMatchObject([
+      {
+        intentId: intent.intentId,
+        status: 'filled',
+        orderId: 'venue-log-1',
+      },
+    ])
+  })
+
   it('returns the latest successful preflight record for execution gating', () => {
     const { service } = buildService()
     const { intent } = service.submitIntent(validIntent, 'req-1')

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -122,6 +122,11 @@ export class ExecutionService {
     return this.repository.getLatestPreflightRecord(intentId)
   }
 
+  listExecutionLogs(intentId: string): ExecutionLogRecord[] {
+    this.getIntent(intentId)
+    return this.repository.listExecutionLogs(intentId)
+  }
+
   getExecutionPreflightRecord(intentId: string): PreflightRecord | null {
     const intent = this.getIntent(intentId)
     const record = this.repository.getLatestPreflightRecord(intentId)
@@ -486,36 +491,47 @@ export class ExecutionService {
     requestId: string,
     mode: 'append' | 'refresh'
   ): void {
-    this.repository.appendExecutionLog(executionLog)
+    const normalizedExecutionLog: ExecutionLogRecord = {
+      ...executionLog,
+      intentId: intent.intentId,
+      venue: intent.venue,
+    }
 
-    const nowIso = executionLog.recordedAt
+    this.repository.appendExecutionLog(normalizedExecutionLog)
+
+    const nowIso = normalizedExecutionLog.recordedAt
     if (mode === 'append') {
       intent.orders.push(
         buildOrderRecordFromExecutionLog({
           intent,
-          executionLog,
+          executionLog: normalizedExecutionLog,
           recordedAt: nowIso,
         })
       )
     } else if (intent.orders.length > 0) {
       intent.orders[intent.orders.length - 1] = updateOrderRecordFromExecutionLog({
         order: intent.orders[intent.orders.length - 1],
-        executionLog,
+        executionLog: normalizedExecutionLog,
         recordedAt: nowIso,
       })
     }
 
-    intent.status = mapExecutionLogToIntentStatus(executionLog.status)
+    intent.status = mapExecutionLogToIntentStatus(normalizedExecutionLog.status)
     intent.updatedAt = nowIso
     if (intent.status === 'executed') {
       intent.executedAt = nowIso
     }
 
     this.repository.saveIntent(intent)
-    this.appendAuditEvent(intent, mapExecutionLogToAuditEventType(executionLog.status), requestId, {
-      externalOrderId: executionLog.orderId,
-      executionStatus: executionLog.status,
-      logId: executionLog.logId,
-    })
+    this.appendAuditEvent(
+      intent,
+      mapExecutionLogToAuditEventType(normalizedExecutionLog.status),
+      requestId,
+      {
+        externalOrderId: normalizedExecutionLog.orderId,
+        executionStatus: normalizedExecutionLog.status,
+        logId: normalizedExecutionLog.logId,
+      }
+    )
   }
 }

--- a/src/routes.integration.test.ts
+++ b/src/routes.integration.test.ts
@@ -559,6 +559,88 @@ describe('integration routes', () => {
     expect(refresh.body.intent.orders.at(-1).status).toBe('filled')
   })
 
+  it('GET /v1/intents/:intentId/preflights and /execution-logs return persisted operator history', async () => {
+    const service = new (await import('./execution/service.js')).ExecutionService({
+      signingAdapter: {
+        async signExecutionRequest(request) {
+          return {
+            ...request,
+            signerRef: 'mock:paper',
+            signature: `sig:${request.requestId}`,
+          }
+        },
+      },
+      executionAdapter: {
+        async placeOrder() {
+          return {
+            logId: 'log-history-filled',
+            intentId: 'intent-history-http',
+            venue: 'paper',
+            status: 'filled' as const,
+            recordedAt: '2026-04-23T00:05:00.000Z',
+            orderId: 'venue-history-http-1',
+            requestId: 'req-execute',
+            preflightOk: true,
+            details: {},
+          }
+        },
+        async cancelOrder() {
+          return {
+            logId: 'log-history-cancelled',
+            intentId: 'intent-history-http',
+            venue: 'paper',
+            status: 'cancelled' as const,
+            recordedAt: '2026-04-23T00:06:00.000Z',
+            orderId: 'venue-history-http-1',
+            requestId: 'req-cancel',
+            preflightOk: true,
+            details: {},
+          }
+        },
+        async getOrderStatus() {
+          return null
+        },
+      },
+    })
+    const { createApp } = await import('./app.js')
+    const app = createApp(1, {
+      executionService: service,
+      preflightEvaluator: {
+        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(true)),
+      },
+    })
+
+    const submit = await request(app).post('/v1/intents').send({
+      intentId: 'intent-history-http',
+      idempotencyKey: 'idem-http-8',
+      accountId: 'acct-primary',
+      market: 'BTC-USD',
+      venue: 'paper',
+      side: 'buy',
+      quantity: 1,
+      notionalUsd: 1000,
+      ttlSeconds: 300,
+    })
+    const intentId = submit.body.intent.intentId
+
+    await request(app).post(`/v1/intents/${intentId}/confirm`).send({})
+    await request(app).post(`/v1/intents/${intentId}/preflight`).send({
+      candidate: buildEnrichedCandidate(),
+    })
+    await request(app).post(`/v1/intents/${intentId}/execute`).send({})
+
+    const preflights = await request(app).get(`/v1/intents/${intentId}/preflights`)
+    const executionLogs = await request(app).get(`/v1/intents/${intentId}/execution-logs`)
+
+    expect(preflights.status).toBe(200)
+    expect(preflights.body.preflightRecords).toHaveLength(1)
+    expect(preflights.body.preflightRecords[0].intentId).toBe(intentId)
+    expect(executionLogs.status).toBe(200)
+    expect(executionLogs.body.executionLogs).toHaveLength(1)
+    expect(executionLogs.body.executionLogs[0].intentId).toBe(intentId)
+    expect(executionLogs.body.executionLogs[0].status).toBe('filled')
+  })
+
   it('POST /analyze/logs returns validation error for bad payload', async () => {
     const { createApp } = await import('./app.js')
     const app = createApp(1)

--- a/src/routes/intents.ts
+++ b/src/routes/intents.ts
@@ -20,7 +20,9 @@ import {
   ExecuteIntentRequestSchema,
   ExecuteIntentResponseSchema,
   IntentRefreshResponseSchema,
+  IntentExecutionLogsResponseSchema,
   IntentPreflightResponseSchema,
+  IntentPreflightHistoryResponseSchema,
   ListCandidatesResponseSchema,
   ListCandidatesRequestSchema,
   ListIntentsResponseSchema,
@@ -193,6 +195,32 @@ export function registerIntentRoutes(
         IntentActionResponseSchema.parse({
           ok: true,
           intent: executionService.getIntent(req.params.intentId),
+        })
+      )
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
+  app.get('/v1/intents/:intentId/preflights', (req: Request, res: Response) => {
+    try {
+      res.status(200).json(
+        IntentPreflightHistoryResponseSchema.parse({
+          ok: true,
+          preflightRecords: executionService.listPreflightRecords(req.params.intentId),
+        })
+      )
+    } catch (error) {
+      respondExecutionError(res, error)
+    }
+  })
+
+  app.get('/v1/intents/:intentId/execution-logs', (req: Request, res: Response) => {
+    try {
+      res.status(200).json(
+        IntentExecutionLogsResponseSchema.parse({
+          ok: true,
+          executionLogs: executionService.listExecutionLogs(req.params.intentId),
         })
       )
     } catch (error) {


### PR DESCRIPTION
## Summary
- add read-only intent history routes for persisted preflight records and execution logs
- expose service-level execution log reads instead of reconstructing history from intent snapshots
- keep the operator history flow strictly read-only and intent-scoped

## Dependency
- built on merged execution refresh and reconciliation from #166

## Files Touched
- `src/execution/schema.ts`
- `src/execution/service.ts`
- `src/routes/intents.ts`
- focused service and route tests

## Tests Run
- `/Users/nsuarez/projects/blackice/node_modules/.bin/vitest run src/execution/service.test.ts src/routes.integration.test.ts`
- `/Users/nsuarez/projects/blackice/node_modules/.bin/tsc -p tsconfig.json`

## Out Of Scope
- background execution loops
- new mutation routes
- CI workflow trigger fixes
