### PR TITLE
chore: harden pull request CI trigger behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,13 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- make the CI workflow explicit about which `pull_request` lifecycle events should trigger runs
- add workflow-level concurrency so stale duplicate PR runs are cancelled instead of racing
- keep the change isolated to GitHub Actions workflow behavior

## Validation
- parsed `.github/workflows/ci.yml` successfully with the repo `yaml` parser via Node

## Out Of Scope
- execution code changes
- route or service behavior changes
- adding new CI jobs
