### PR TITLE
test(issue-126): add focused log explainer query guard coverage

### DIFF
--- a/src/logExplainer/logCollector.test.ts
+++ b/src/logExplainer/logCollector.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const tempDirs: string[] = []
 
-function writeRuntimeConfig(): string {
+function writeRuntimeConfig(options: { maxResponseBytes?: number } = {}): string {
   const dir = mkdtempSync(path.join(tmpdir(), 'blackice-loki-test-'))
   const configFile = path.join(dir, 'blackice.test.yaml')
   const rulesFile = path.join(dir, 'loki-rules.yaml')
@@ -16,7 +16,7 @@ function writeRuntimeConfig(): string {
 loki:
   baseUrl: http://127.0.0.1:3100
   rulesFile: ./loki-rules.yaml
-`
+${options.maxResponseBytes === undefined ? '' : `  maxResponseBytes: ${options.maxResponseBytes}\n`}`
   )
   writeFileSync(
     rulesFile,
@@ -113,6 +113,138 @@ describe('log explainer Loki helpers', () => {
         limit: 10,
       })
     ).rejects.toThrow('Loki query must include host or unit label')
+  })
+
+  it('rejects raw queries and filters outside the configured Loki allowlist', async () => {
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+    const { buildEffectiveLokiQuery } = await import('./logCollector.js')
+
+    expect(() =>
+      buildEffectiveLokiQuery({
+        source: 'loki',
+        query: '{job="blackice"}',
+        filters: { job: 'blackice', host: 'node-1' },
+      })
+    ).toThrow('raw Loki query is not allowed')
+
+    expect(() =>
+      buildEffectiveLokiQuery({
+        source: 'loki',
+        filters: { job: 'blackice', namespace: 'prod' },
+      })
+    ).toThrow('Loki label "namespace" is not allowed')
+
+    expect(() =>
+      buildEffectiveLokiQuery({
+        source: 'loki',
+        filters: { job: 'blackice', host: 'node-2' },
+      })
+    ).toThrow('Loki host "node-2" is not allowed')
+  })
+
+  it('validates selector guard syntax and allowlist rules directly', async () => {
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+    const { validateAllowedLokiSelector } = await import('./logCollector.js')
+
+    expect(validateAllowedLokiSelector('{ unit = "blackice.service", job="blackice" }')).toBe(
+      '{job="blackice",unit="blackice.service"}'
+    )
+    expect(() => validateAllowedLokiSelector('{job=~"blackice"}')).toThrow(
+      'selector contains unsupported operators'
+    )
+    expect(() => validateAllowedLokiSelector('{job="blackice",namespace="prod"}')).toThrow(
+      'Loki label "namespace" is not allowed'
+    )
+  })
+
+  it('returns empty logs for empty Loki stream results', async () => {
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: 'success',
+          data: {
+            resultType: 'streams',
+            result: [],
+          },
+        }),
+      })
+    )
+    const { collectLokiBatchLogs } = await import('./logCollector.js')
+
+    const result = await collectLokiBatchLogs({
+      source: 'loki',
+      filters: { job: 'blackice', host: 'node-1' },
+      limit: 10,
+    })
+
+    expect(result.logs).toBe('')
+  })
+
+  it('rejects malformed Loki query_range payloads', async () => {
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: 'success',
+          data: {
+            resultType: 'matrix',
+            result: [],
+          },
+        }),
+      })
+    )
+    const { collectLokiBatchLogs } = await import('./logCollector.js')
+
+    await expect(
+      collectLokiBatchLogs({
+        source: 'loki',
+        filters: { job: 'blackice', host: 'node-1' },
+        limit: 10,
+      })
+    ).rejects.toThrow('Loki returned an unexpected query_range payload')
+  })
+
+  it('formats stream labels and marks Loki output truncated at the response byte cap', async () => {
+    vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig({ maxResponseBytes: 1000 }))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: 'success',
+          data: {
+            resultType: 'streams',
+            result: [
+              {
+                stream: { unit: 'blackice.service', host: 'node-1' },
+                values: [
+                  ['1000000', 'short line'],
+                  ['2000000', 'x'.repeat(1200)],
+                ],
+              },
+            ],
+          },
+        }),
+      })
+    )
+    const { collectLokiBatchLogs } = await import('./logCollector.js')
+
+    const result = await collectLokiBatchLogs({
+      source: 'loki',
+      filters: { job: 'blackice', host: 'node-1' },
+      limit: 10,
+    })
+
+    expect(result.logs).toContain(
+      '1970-01-01T00:00:00.001Z [host=node-1,unit=blackice.service] short line'
+    )
+    expect(result.logs).toContain('[truncated] Loki response exceeded LOKI_MAX_RESPONSE_BYTES')
+    expect(result.logs).not.toContain('x'.repeat(1200))
   })
 
   it('resolves sinceSeconds windows from the current clock', async () => {

--- a/src/logExplainer/route.test.ts
+++ b/src/logExplainer/route.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tempDirs: string[] = []
+
+function writeRuntimeConfig(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-log-route-test-'))
+  const configFile = path.join(dir, 'blackice.test.yaml')
+
+  writeFileSync(
+    configFile,
+    `version: 1
+loki:
+  baseUrl: ''
+`
+  )
+
+  tempDirs.push(dir)
+  return configFile
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+  vi.stubEnv('BLACKICE_CONFIG_FILE', writeRuntimeConfig())
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('log explainer route helpers', () => {
+  it('resolves legacy batch flags without overriding explicit mode', async () => {
+    const { resolveBatchMode } = await import('./route.js')
+
+    expect(resolveBatchMode({})).toEqual({ mode: 'analyze', legacyCollectOnly: false })
+    expect(resolveBatchMode({ analyze: false })).toEqual({
+      mode: 'raw',
+      legacyCollectOnly: true,
+    })
+    expect(resolveBatchMode({ collectOnly: true })).toEqual({
+      mode: 'raw',
+      legacyCollectOnly: true,
+    })
+    expect(resolveBatchMode({ mode: 'both', analyze: false, collectOnly: true })).toEqual({
+      mode: 'both',
+      legacyCollectOnly: false,
+    })
+  })
+
+  it('only enables evidence defaults for raw or both batch modes', async () => {
+    const { BATCH_EVIDENCE_LINES_DEFAULT } = await import('./schema.js')
+    const { resolveEvidenceLinesForMode } = await import('./route.js')
+
+    expect(resolveEvidenceLinesForMode('analyze', undefined)).toBeUndefined()
+    expect(resolveEvidenceLinesForMode('raw', undefined)).toBe(BATCH_EVIDENCE_LINES_DEFAULT)
+    expect(resolveEvidenceLinesForMode('both', undefined)).toBe(BATCH_EVIDENCE_LINES_DEFAULT)
+    expect(resolveEvidenceLinesForMode('raw', 3)).toBe(3)
+    expect(resolveEvidenceLinesForMode('both', 4)).toBe(4)
+  })
+})

--- a/src/logExplainer/route.ts
+++ b/src/logExplainer/route.ts
@@ -69,7 +69,11 @@ const RATE_LIMIT_POLICIES: Record<'analyze' | 'batch', RateLimitPolicy> = {
 }
 const rateLimitBuckets = new Map<string, RateLimitBucket>()
 
-function resolveBatchMode(input: { mode?: BatchMode; analyze?: boolean; collectOnly?: boolean }): {
+export function resolveBatchMode(input: {
+  mode?: BatchMode
+  analyze?: boolean
+  collectOnly?: boolean
+}): {
   mode: BatchMode
   legacyCollectOnly: boolean
 } {
@@ -93,7 +97,7 @@ function resolveBatchMode(input: { mode?: BatchMode; analyze?: boolean; collectO
   }
 }
 
-function resolveEvidenceLinesForMode(
+export function resolveEvidenceLinesForMode(
   mode: BatchMode,
   requested: number | undefined
 ): number | undefined {


### PR DESCRIPTION
Closes #126

## Summary
- Adds focused unit coverage for Loki query guard behavior, selector normalization, allowlist enforcement, malformed/empty Loki payloads, and Loki truncation formatting.
- Adds localized route-helper coverage for batch mode and evidence-line defaults.
- Exports existing pure route helpers for direct tests without changing runtime behavior.

## Ownership Boundary
- Log explainer helper tests only, with a small helper export for testability.
- Files touched: `src/logExplainer/logCollector.test.ts`, `src/logExplainer/route.test.ts`, `src/logExplainer/route.ts`.

## Dependency Confirmation
- Based on current `origin/main` at `11122da`.
- No dependency on other active PRs.

## Tests Run
- `pnpm exec vitest run src/logExplainer/logCollector.test.ts src/logExplainer/route.test.ts src/logExplainer/evidence.test.ts`
- `pnpm run build`
- Push hook: `pnpm run format:branch:check`

## Out Of Scope
- Runtime behavior refactors beyond exporting pure helpers.
- Full Express route integration rewrites.
- Config/startup validation, command/path safety, chat streaming, metrics, and execution routes.
