### PR TITLE
fix(issue-26): centralize startup config validation

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -193,27 +193,41 @@ const RuntimeConfigSchema = z
 
 export type RuntimeConfig = z.infer<typeof RuntimeConfigSchema>
 
+function formatIssuePath(issue: z.core.$ZodIssue): string {
+  return issue.path.length > 0 ? issue.path.map(String).join('.') : '<root>'
+}
+
+function formatValidationIssues(error: z.ZodError): string {
+  return error.issues.map((issue) => `${formatIssuePath(issue)}: ${issue.message}`).join('; ')
+}
+
 function loadYamlConfig(filePath: string): z.infer<typeof YamlConfigSchema> {
   if (!existsSync(filePath)) {
     throw new Error(`Config file not found: ${filePath}`)
   }
 
   const raw = readFileSync(filePath, 'utf8')
-  const parsed = parseYaml(raw)
+  let parsed: unknown
+  try {
+    parsed = parseYaml(raw)
+  } catch (error) {
+    throw new Error(
+      `Invalid config file ${filePath}: YAML parse error: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+
   const result = YamlConfigSchema.safeParse(parsed)
   if (!result.success) {
-    throw new Error(`Invalid config file: ${result.error.issues.map((i) => i.message).join('; ')}`)
+    throw new Error(`Invalid config file ${filePath}: ${formatValidationIssues(result.error)}`)
   }
   return result.data
 }
 
 let cachedRuntimeConfig: RuntimeConfig | null = null
 
-export function getRuntimeConfig(): RuntimeConfig {
-  if (cachedRuntimeConfig) {
-    return cachedRuntimeConfig
-  }
-
+function loadRuntimeConfigFromEnv(): RuntimeConfig {
   const configFileRaw = String(process.env.BLACKICE_CONFIG_FILE ?? DEFAULT_CONFIG_FILE).trim()
   const configFile = path.resolve(configFileRaw)
   const yamlConfig = loadYamlConfig(configFile)
@@ -313,7 +327,7 @@ export function getRuntimeConfig(): RuntimeConfig {
     storagePath: String(executionYaml.storagePath ?? DEFAULT_EXECUTION_STORAGE_PATH).trim(),
   }
 
-  cachedRuntimeConfig = RuntimeConfigSchema.parse({
+  const result = RuntimeConfigSchema.safeParse({
     configFile,
     server,
     readiness,
@@ -325,5 +339,22 @@ export function getRuntimeConfig(): RuntimeConfig {
     execution,
     limits,
   })
+  if (!result.success) {
+    throw new Error(`Invalid runtime config ${configFile}: ${formatValidationIssues(result.error)}`)
+  }
+
+  return result.data
+}
+
+export function validateRuntimeConfig(): RuntimeConfig {
+  return getRuntimeConfig()
+}
+
+export function getRuntimeConfig(): RuntimeConfig {
+  if (cachedRuntimeConfig) {
+    return cachedRuntimeConfig
+  }
+
+  cachedRuntimeConfig = loadRuntimeConfigFromEnv()
   return cachedRuntimeConfig
 }

--- a/src/runtimeConfig.test.ts
+++ b/src/runtimeConfig.test.ts
@@ -11,6 +11,12 @@ function writeConfig(contents: string): string {
   return file
 }
 
+function missingConfigPath(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-runtime-config-'))
+  tempDirs.push(dir)
+  return path.join(dir, 'missing.yaml')
+}
+
 const tempDirs: string[] = []
 
 beforeEach(() => {
@@ -140,6 +146,32 @@ server:
     })
   })
 
+  it('fills valid defaults when optional sections are missing', async () => {
+    const configFile = writeConfig(`version: 1
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(getRuntimeConfig()).toMatchObject({
+      server: { port: 3000 },
+      readiness: { timeoutMs: 1500, strict: true },
+      ops: { enabled: false, logBufferMaxEntries: 2000 },
+      debate: {
+        maxConcurrent: 1,
+        modelAllowlist: ['llama3.1:8b', 'qwen2.5:14b', 'qwen2.5-coder:14b'],
+      },
+      ollama: {
+        baseUrl: 'http://192.168.1.230:11434',
+        model: 'qwen2.5:14b',
+      },
+      execution: {
+        defaultVenue: 'paper',
+        allowedVenues: ['paper'],
+      },
+    })
+  })
+
   it('aligns default allowed venues with a configured default venue', async () => {
     const configFile = writeConfig(`version: 1
 execution:
@@ -156,5 +188,59 @@ execution:
         storagePath: '',
       },
     })
+  })
+
+  it('reports YAML parse failures with the selected config file path', async () => {
+    const configFile = writeConfig(`version: [
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(() => getRuntimeConfig()).toThrow(`Invalid config file ${configFile}: YAML parse error:`)
+  })
+
+  it('reports schema validation failures with field paths', async () => {
+    const configFile = writeConfig(`version: 1
+ops:
+  logBufferMaxEntries: 10
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(() => getRuntimeConfig()).toThrow(/ops\.logBufferMaxEntries:/)
+  })
+
+  it('rejects unknown top-level config keys with a root-level message', async () => {
+    const configFile = writeConfig(`version: 1
+unexpected: true
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(() => getRuntimeConfig()).toThrow(/<root>: Unrecognized key/)
+  })
+
+  it('rejects empty execution venue allowlists after normalization', async () => {
+    const configFile = writeConfig(`version: 1
+execution:
+  allowedVenues: []
+`)
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(() => getRuntimeConfig()).toThrow(/execution\.allowedVenues:/)
+  })
+
+  it('fails when BLACKICE_CONFIG_FILE selects a missing file', async () => {
+    const configFile = missingConfigPath()
+
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(() => getRuntimeConfig()).toThrow(`Config file not found: ${configFile}`)
   })
 })

--- a/src/startupPreflight.test.ts
+++ b/src/startupPreflight.test.ts
@@ -4,6 +4,11 @@ const mocks = vi.hoisted(() => ({
   checkModelAvailability: vi.fn(),
   getConfiguredOllamaModel: vi.fn(() => 'qwen2.5:14b'),
   logInfo: vi.fn(),
+  validateRuntimeConfig: vi.fn(),
+}))
+
+vi.mock('./config/runtimeConfig.js', () => ({
+  validateRuntimeConfig: mocks.validateRuntimeConfig,
 }))
 
 vi.mock('./ollama.js', () => ({
@@ -24,6 +29,7 @@ describe('runStartupModelPreflight', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    mocks.validateRuntimeConfig.mockReturnValue({})
     process.env = {
       ...originalEnv,
       MODEL_PREFLIGHT_ON_START: '1',
@@ -36,6 +42,20 @@ describe('runStartupModelPreflight', () => {
     const { runStartupModelPreflight } = await import('./startupPreflight.js')
     await runStartupModelPreflight()
 
+    expect(mocks.validateRuntimeConfig).toHaveBeenCalledOnce()
+    expect(mocks.checkModelAvailability).not.toHaveBeenCalled()
+  })
+
+  it('fails startup when runtime config validation fails', async () => {
+    mocks.validateRuntimeConfig.mockImplementation(() => {
+      throw new Error('Invalid runtime config: execution.allowedVenues: Too small')
+    })
+
+    const { runStartupModelPreflight } = await import('./startupPreflight.js')
+
+    await expect(runStartupModelPreflight()).rejects.toThrow(
+      'Invalid runtime config: execution.allowedVenues: Too small'
+    )
     expect(mocks.checkModelAvailability).not.toHaveBeenCalled()
   })
 
@@ -53,6 +73,7 @@ describe('runStartupModelPreflight', () => {
     await expect(runStartupModelPreflight()).rejects.toThrow(
       'startup_preflight_failed_model_not_found:missing-model'
     )
+    expect(mocks.validateRuntimeConfig).toHaveBeenCalledOnce()
   })
 
   it('logs success when the configured model is available', async () => {
@@ -67,6 +88,7 @@ describe('runStartupModelPreflight', () => {
     const { runStartupModelPreflight } = await import('./startupPreflight.js')
     await runStartupModelPreflight()
 
+    expect(mocks.validateRuntimeConfig).toHaveBeenCalledOnce()
     expect(mocks.logInfo).toHaveBeenCalledWith('startup_model_preflight_ok', {
       model: 'qwen2.5:14b',
       latency_ms: 21,

--- a/src/startupPreflight.ts
+++ b/src/startupPreflight.ts
@@ -1,8 +1,11 @@
 import { env } from './config/env.js'
+import { validateRuntimeConfig } from './config/runtimeConfig.js'
 import { checkModelAvailability, getConfiguredOllamaModel, ollamaBaseURL } from './ollama.js'
 import { log } from './log.js'
 
 export async function runStartupModelPreflight(): Promise<void> {
+  validateRuntimeConfig()
+
   if (!env.MODEL_PREFLIGHT_ON_START) {
     return
   }


### PR DESCRIPTION
Closes #26

## Summary
- Centralizes runtime config validation behind an explicit validation entrypoint used during startup preflight.
- Preserves existing runtime config defaults while improving error messages for missing files, YAML parse errors, schema paths, and runtime normalization failures.
- Adds focused tests for defaults, selected missing config files, invalid YAML, schema paths, normalized runtime validation, and startup preflight failure behavior.

## Ownership Boundary
- Config/runtime validation and startup preflight only.
- Files touched: `src/config/runtimeConfig.ts`, `src/startupPreflight.ts`, `src/runtimeConfig.test.ts`, `src/startupPreflight.test.ts`.

## Dependency Confirmation
- Based on current `origin/main` at `11122da`.
- No dependency on other active PRs.

## Tests Run
- `pnpm exec vitest run src/runtimeConfig.test.ts src/startupPreflight.test.ts`
- `pnpm run build`
- Push hook: `pnpm run format:branch:check`

## Out Of Scope
- Command/path allowlist refactors for #98.
- Log explainer tests for #126.
- Chat streaming, metrics, execution routes, and route behavior changes.
