### PR TITLE
refactor(issue-98): centralize command execution and path allowlist helpers

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ActionEnvelope } from './schema.js'
+
+const runCommand = vi.fn()
+const isPathWithinAllowlist = vi.fn()
+
+vi.mock('./safety.js', () => ({
+  createBoundedCommandRunner: vi.fn(() => runCommand),
+  isPathWithinAllowlist,
+}))
+
+vi.mock('./ollama.js', () => ({
+  runWorkerText: vi.fn(),
+}))
+
+vi.mock('./router.js', () => ({
+  chooseActionModel: vi.fn(() => ({ model: 'test-model' })),
+}))
+
+function tailLogAction(path: string, lines?: number): ActionEnvelope {
+  return {
+    action: 'tail_log',
+    input: '',
+    options: lines === undefined ? { path } : { path, lines },
+  }
+}
+
+beforeEach(() => {
+  runCommand.mockReset()
+  isPathWithinAllowlist.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('actions command and path safety', () => {
+  it('tails allowlisted paths through the shared bounded command runner', async () => {
+    isPathWithinAllowlist.mockResolvedValue(true)
+    runCommand.mockResolvedValue('line 1\nline 2')
+    const { executeAction } = await import('./actions.js')
+
+    const result = await executeAction(tailLogAction('/var/log/app.log', 999))
+
+    expect(isPathWithinAllowlist).toHaveBeenCalledWith('/var/log/app.log', [
+      '/var/log/syslog',
+      '/var/log/auth.log',
+    ])
+    expect(runCommand).toHaveBeenCalledWith('tail', ['-n', '500', '/var/log/app.log'])
+    expect(result).toEqual({
+      action: 'tail_log',
+      text: 'tail_log(/var/log/app.log, lines=500):\nline 1\nline 2',
+    })
+  })
+
+  it('rejects denied paths before invoking a command', async () => {
+    isPathWithinAllowlist.mockResolvedValue(false)
+    const { executeAction } = await import('./actions.js')
+
+    await expect(executeAction(tailLogAction('/etc/passwd'))).rejects.toThrow(
+      'Requested path is not allowlisted.'
+    )
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+})

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@ import os from 'node:os'
 import type { ActionEnvelope } from './schema.js'
 import { runWorkerText } from './ollama.js'
 import { chooseActionModel } from './router.js'
-import { isPathWithinAllowlist, runBoundedCommand } from './safety.js'
+import { createBoundedCommandRunner, isPathWithinAllowlist } from './safety.js'
 const ACTIONS_ENABLED = (process.env.ACTIONS_ENABLED ?? 'true').toLowerCase() === 'true'
 const COMMAND_TIMEOUT_MS = 4_000
 const COMMAND_MAX_BYTES = 1024 * 1024
@@ -24,12 +24,10 @@ type ActionExecutionMetadata = {
   safetyIdentifier?: string
 }
 
-async function runSafeCmd(file: string, args: string[]): Promise<string> {
-  return runBoundedCommand(file, args, {
-    timeoutMs: COMMAND_TIMEOUT_MS,
-    maxBytes: COMMAND_MAX_BYTES,
-  })
-}
+const runActionCommand = createBoundedCommandRunner({
+  timeoutMs: COMMAND_TIMEOUT_MS,
+  maxBytes: COMMAND_MAX_BYTES,
+})
 
 async function runSummaryAction(
   action: ActionEnvelope,
@@ -58,7 +56,7 @@ async function runSummaryAction(
 async function healthcheck(): Promise<string> {
   const hostname = os.hostname()
   const uptimeSec = Math.floor(os.uptime())
-  const diskUsage = await runSafeCmd('df', ['-h', '/'])
+  const diskUsage = await runActionCommand('df', ['-h', '/'])
 
   return [`hostname: ${hostname}`, `uptime_seconds: ${uptimeSec}`, 'disk_usage:', diskUsage].join(
     '\n'
@@ -70,7 +68,11 @@ async function listServices(options: Record<string, unknown>): Promise<string> {
 
   if (mode === 'docker' || mode === 'auto') {
     try {
-      const dockerOut = await runSafeCmd('docker', ['ps', '--format', '{{.Names}}\t{{.Status}}'])
+      const dockerOut = await runActionCommand('docker', [
+        'ps',
+        '--format',
+        '{{.Names}}\t{{.Status}}',
+      ])
       if (dockerOut) {
         return `docker_containers:\n${dockerOut}`
       }
@@ -82,7 +84,7 @@ async function listServices(options: Record<string, unknown>): Promise<string> {
   }
 
   if (mode === 'systemd' || mode === 'auto') {
-    const systemdOut = await runSafeCmd('systemctl', [
+    const systemdOut = await runActionCommand('systemctl', [
       'list-units',
       '--type=service',
       '--state=running',
@@ -113,7 +115,7 @@ async function tailLog(options: Record<string, unknown>): Promise<string> {
     throw new Error('Requested path is not allowlisted.')
   }
 
-  const output = await runSafeCmd('tail', ['-n', String(lines), file])
+  const output = await runActionCommand('tail', ['-n', String(lines), file])
   return `tail_log(${file}, lines=${lines}):\n${output}`
 }
 

--- a/src/logExplainer/logCollector.ts
+++ b/src/logExplainer/logCollector.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import type { AnalyzeLogsBatchLokiRequest, AnalyzeLogsRequest } from './schema.js'
 import { getRuntimeConfig } from '../config/runtimeConfig.js'
-import { runBoundedCommand } from '../safety.js'
+import { createBoundedCommandRunner } from '../safety.js'
 
 const runtimeConfig = getRuntimeConfig()
 const LOG_COLLECTION_TIMEOUT_MS = Number(runtimeConfig.limits.logCollectionTimeoutMs)
@@ -84,21 +84,29 @@ function clampMaxLines(maxLines: number): number {
   return Math.min(maxLines, MAX_LINES_CAP)
 }
 
-function runAllowedCommand(command: 'journalctl' | 'docker', args: string[]): Promise<string> {
-  return runBoundedCommand(command, args, {
-    timeoutMs: LOG_COLLECTION_TIMEOUT_MS,
-    maxBytes: MAX_COMMAND_BYTES,
-    onError: (message, status) => {
-      if (status === 504) {
-        return buildError(504, `log collection timed out for ${command}`)
-      }
-      if (status === 413) {
-        return buildError(413, 'command output exceeds MAX_COMMAND_BYTES limit')
-      }
-      return buildError(status ?? 500, message)
-    },
-  })
+function buildCommandError(command: 'journalctl' | 'docker') {
+  return (message: string, status?: number): Error => {
+    if (status === 504) {
+      return buildError(504, `log collection timed out for ${command}`)
+    }
+    if (status === 413) {
+      return buildError(413, 'command output exceeds MAX_COMMAND_BYTES limit')
+    }
+    return buildError(status ?? 500, message)
+  }
 }
+
+const runJournalctlCommand = createBoundedCommandRunner({
+  timeoutMs: LOG_COLLECTION_TIMEOUT_MS,
+  maxBytes: MAX_COMMAND_BYTES,
+  onError: buildCommandError('journalctl'),
+})
+
+const runDockerCommand = createBoundedCommandRunner({
+  timeoutMs: LOG_COLLECTION_TIMEOUT_MS,
+  maxBytes: MAX_COMMAND_BYTES,
+  onError: buildCommandError('docker'),
+})
 
 async function collectJournalctlLogs(input: AnalyzeLogsRequest): Promise<string> {
   const safeTarget = sanitizeTarget(input.target)
@@ -118,7 +126,7 @@ async function collectJournalctlLogs(input: AnalyzeLogsRequest): Promise<string>
     args.push('-u', safeTarget)
   }
 
-  return runAllowedCommand('journalctl', args)
+  return runJournalctlCommand('journalctl', args)
 }
 
 async function collectDockerLogs(input: AnalyzeLogsRequest): Promise<string> {
@@ -129,7 +137,7 @@ async function collectDockerLogs(input: AnalyzeLogsRequest): Promise<string> {
   const sinceDate = new Date(Date.now() - safeHours * 60 * 60 * 1000).toISOString()
   const args = ['logs', '--tail', String(safeMaxLines), '--since', sinceDate, safeTarget]
 
-  return runAllowedCommand('docker', args)
+  return runDockerCommand('docker', args)
 }
 
 function parseStringArray(value: unknown, field: string, required: boolean): string[] {

--- a/src/safety.test.ts
+++ b/src/safety.test.ts
@@ -1,14 +1,79 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { isPathWithinAllowlist } from './safety.js'
+import { isPathWithinAllowlist, resolveAllowlistedPath, runBoundedCommand } from './safety.js'
 
 afterEach(() => {
   vi.restoreAllMocks()
 })
 
 describe('safety.ts', () => {
+  it('runs bounded commands and trims successful stdout', async () => {
+    await expect(
+      runBoundedCommand(process.execPath, ['-e', 'process.stdout.write(" ok\\n")'], {
+        timeoutMs: 1_000,
+        maxBytes: 1024,
+      })
+    ).resolves.toBe('ok')
+  })
+
+  it('maps command failures through the configured error builder', async () => {
+    await expect(
+      runBoundedCommand(process.execPath, ['-e', 'process.stderr.write("bad"); process.exit(2)'], {
+        timeoutMs: 1_000,
+        maxBytes: 1024,
+        onError: (message, status) => Object.assign(new Error(message), { status }),
+      })
+    ).rejects.toMatchObject({
+      message: `${process.execPath} failed: bad`,
+      status: 502,
+    })
+  })
+
+  it('cancels commands when the abort signal fires', async () => {
+    const controller = new AbortController()
+    const command = runBoundedCommand(process.execPath, ['-e', 'setTimeout(() => {}, 1000)'], {
+      timeoutMs: 1_000,
+      maxBytes: 1024,
+      signal: controller.signal,
+      onError: (message, status) => Object.assign(new Error(message), { status }),
+    })
+
+    controller.abort()
+
+    await expect(command).rejects.toMatchObject({
+      message: `command cancelled for ${process.execPath}`,
+      status: 499,
+    })
+  })
+
+  it('terminates commands that exceed the timeout', async () => {
+    await expect(
+      runBoundedCommand(process.execPath, ['-e', 'setTimeout(() => {}, 1000)'], {
+        timeoutMs: 25,
+        maxBytes: 1024,
+        onError: (message, status) => Object.assign(new Error(message), { status }),
+      })
+    ).rejects.toMatchObject({
+      message: `command timed out for ${process.execPath}`,
+      status: 504,
+    })
+  })
+
+  it('terminates commands that exceed the output byte limit', async () => {
+    await expect(
+      runBoundedCommand(process.execPath, ['-e', 'process.stdout.write("x".repeat(2048))'], {
+        timeoutMs: 1_000,
+        maxBytes: 64,
+        onError: (message, status) => Object.assign(new Error(message), { status }),
+      })
+    ).rejects.toMatchObject({
+      message: 'command output exceeded byte limit',
+      status: 413,
+    })
+  })
+
   it('allows files inside an allowlisted directory', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'blackice-safety-'))
     const allowedDir = path.join(root, 'logs')
@@ -19,6 +84,18 @@ describe('safety.ts', () => {
     await writeFile(targetFile, 'ok\n', 'utf8')
 
     await expect(isPathWithinAllowlist(targetFile, [allowedDir])).resolves.toBe(true)
+    await expect(resolveAllowlistedPath(targetFile, [allowedDir])).resolves.toBe(
+      await realpath(targetFile)
+    )
+  })
+
+  it('allows files that are explicitly allowlisted', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'blackice-safety-'))
+    const targetFile = path.join(root, 'app.log')
+
+    await writeFile(targetFile, 'ok\n', 'utf8')
+
+    await expect(isPathWithinAllowlist(targetFile, [targetFile])).resolves.toBe(true)
   })
 
   it('rejects sibling files outside an allowlisted directory', async () => {
@@ -34,6 +111,20 @@ describe('safety.ts', () => {
     await expect(isPathWithinAllowlist(targetFile, [allowedDir])).resolves.toBe(false)
   })
 
+  it('rejects traversal paths that resolve outside an allowlisted directory', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'blackice-safety-'))
+    const allowedDir = path.join(root, 'logs')
+    const outsideDir = path.join(root, 'outside')
+    const targetFile = path.join(outsideDir, 'app.log')
+    const traversalPath = path.join(allowedDir, '..', 'outside', 'app.log')
+
+    await mkdir(allowedDir, { recursive: true })
+    await mkdir(outsideDir, { recursive: true })
+    await writeFile(targetFile, 'nope\n', 'utf8')
+
+    await expect(isPathWithinAllowlist(traversalPath, [allowedDir])).resolves.toBe(false)
+  })
+
   it('resolves symlinked allowlist entries before checking containment', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'blackice-safety-'))
     const realDir = path.join(root, 'real')
@@ -45,5 +136,20 @@ describe('safety.ts', () => {
     await symlink(realDir, aliasDir)
 
     await expect(isPathWithinAllowlist(targetFile, [aliasDir])).resolves.toBe(true)
+  })
+
+  it('rejects symlinked requested paths that escape an allowlisted directory', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'blackice-safety-'))
+    const allowedDir = path.join(root, 'logs')
+    const outsideDir = path.join(root, 'outside')
+    const outsideFile = path.join(outsideDir, 'app.log')
+    const linkFile = path.join(allowedDir, 'app.log')
+
+    await mkdir(allowedDir, { recursive: true })
+    await mkdir(outsideDir, { recursive: true })
+    await writeFile(outsideFile, 'nope\n', 'utf8')
+    await symlink(outsideFile, linkFile)
+
+    await expect(isPathWithinAllowlist(linkFile, [allowedDir])).resolves.toBe(false)
   })
 })

--- a/src/safety.ts
+++ b/src/safety.ts
@@ -2,14 +2,20 @@ import { spawn } from 'node:child_process'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 
-type BoundedCommandOptions = {
+export type BoundedCommandOptions = {
   timeoutMs: number
   maxBytes: number
   onError?: (message: string, status?: number) => Error
+  signal?: AbortSignal
 }
 
 function buildDefaultError(message: string): Error {
   return new Error(message)
+}
+
+export function createBoundedCommandRunner(options: BoundedCommandOptions) {
+  return (command: string, args: string[]): Promise<string> =>
+    runBoundedCommand(command, args, options)
 }
 
 export function runBoundedCommand(
@@ -29,14 +35,31 @@ export function runBoundedCommand(
     let stdout = ''
     let stderr = ''
 
-    const timeout = setTimeout(() => {
+    const finish = (callback: () => void): void => {
       if (settled) {
         return
       }
       settled = true
+      clearTimeout(timeout)
+      options.signal?.removeEventListener('abort', abortCommand)
+      callback()
+    }
+
+    const timeout = setTimeout(() => {
       child.kill('SIGKILL')
-      reject(toError(`command timed out for ${command}`, 504))
+      finish(() => reject(toError(`command timed out for ${command}`, 504)))
     }, options.timeoutMs)
+
+    const abortCommand = (): void => {
+      child.kill('SIGKILL')
+      finish(() => reject(toError(`command cancelled for ${command}`, 499)))
+    }
+
+    if (options.signal?.aborted) {
+      abortCommand()
+      return
+    }
+    options.signal?.addEventListener('abort', abortCommand, { once: true })
 
     child.stdout.on('data', (buf: Buffer) => {
       if (settled) {
@@ -45,9 +68,8 @@ export function runBoundedCommand(
 
       stdout += buf.toString('utf8')
       if (Buffer.byteLength(stdout, 'utf8') > options.maxBytes) {
-        settled = true
         child.kill('SIGKILL')
-        reject(toError('command output exceeded byte limit', 413))
+        finish(() => reject(toError('command output exceeded byte limit', 413)))
       }
     })
 
@@ -62,37 +84,40 @@ export function runBoundedCommand(
       if (settled) {
         return
       }
-      settled = true
-      clearTimeout(timeout)
-      reject(toError(`failed to execute ${command}: ${error.message}`, 500))
+      finish(() => reject(toError(`failed to execute ${command}: ${error.message}`, 500)))
     })
 
     child.on('close', (code: number | null) => {
       if (settled) {
         return
       }
-      settled = true
-      clearTimeout(timeout)
 
       if (code !== 0) {
-        reject(toError(`${command} failed: ${stderr.trim() || `exit code ${String(code)}`}`, 502))
+        finish(() =>
+          reject(toError(`${command} failed: ${stderr.trim() || `exit code ${String(code)}`}`, 502))
+        )
         return
       }
 
-      resolve(stdout.trim())
+      finish(() => resolve(stdout.trim()))
     })
   })
 }
 
-export async function isPathWithinAllowlist(
+function isRealPathContained(realRequested: string, realAllowed: string): boolean {
+  const relative = path.relative(realAllowed, realRequested)
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative)
+}
+
+export async function resolveAllowlistedPath(
   requestedPath: string,
   allowlistedEntries: string[]
-): Promise<boolean> {
+): Promise<string | null> {
   let realRequested: string
   try {
     realRequested = await fs.realpath(requestedPath)
   } catch {
-    return false
+    return null
   }
 
   for (const entry of allowlistedEntries) {
@@ -100,17 +125,21 @@ export async function isPathWithinAllowlist(
       const realAllowed = await fs.realpath(entry)
       const stat = await fs.stat(realAllowed)
       if (stat.isDirectory()) {
-        const normalized = realAllowed.endsWith(path.sep)
-          ? realAllowed
-          : `${realAllowed}${path.sep}`
-        if (realRequested.startsWith(normalized)) {
-          return true
+        if (isRealPathContained(realRequested, realAllowed)) {
+          return realRequested
         }
       } else if (realRequested === realAllowed) {
-        return true
+        return realRequested
       }
     } catch {}
   }
 
-  return false
+  return null
+}
+
+export async function isPathWithinAllowlist(
+  requestedPath: string,
+  allowlistedEntries: string[]
+): Promise<boolean> {
+  return (await resolveAllowlistedPath(requestedPath, allowlistedEntries)) !== null
 }


### PR DESCRIPTION
Closes #98

## Summary
- Centralizes bounded command execution behind shared safety helpers.
- Adds shared realpath-based allowlist resolution for requested paths.
- Updates actions and log collection command paths to reuse the shared bounded command runner without widening command or filesystem access.
- Adds focused tests for command success/failure/timeout/cancellation, byte limits, explicit file allowlists, directory containment, traversal, and symlink escape behavior.

## Ownership Boundary
- Command execution and path safety only.
- Files touched: `src/safety.ts`, `src/actions.ts`, `src/logExplainer/logCollector.ts`, `src/safety.test.ts`, `src/actions.test.ts`.

## Dependency Confirmation
- Based on current `origin/main` at `d71c86e`.
- Wave 1 PRs #169 and #170 are merged.

## Tests Run
- `pnpm exec vitest run src/actions.test.ts src/safety.test.ts src/logExplainer/logCollector.test.ts`
- `pnpm run build`
- Push hook: `pnpm run format:branch:check`

## Out Of Scope
- Chat streaming gating for #5.
- Config/startup validation.
- Metrics, execution routes, and broad route rewrites.
- Any expansion of allowed command or filesystem access policy.
