### PR TITLE
fix(issue-5): harden streaming output gating

### DIFF
--- a/src/chat/streaming.test.ts
+++ b/src/chat/streaming.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const runWorkerTextStream = vi.fn()
 
@@ -43,9 +43,137 @@ function parseSsePayloads(chunks: string[]) {
     .map((chunk) => JSON.parse(chunk.slice('data: '.length).trim()))
 }
 
+function streamedContent(chunks: string[]) {
+  return parseSsePayloads(chunks)
+    .map((payload) => payload.choices?.[0]?.delta?.content)
+    .filter((content): content is string => typeof content === 'string')
+    .join('')
+}
+
 describe('handleChatStreaming', () => {
-  it('falls back before content and keeps a single model in emitted chunks', async () => {
+  beforeEach(() => {
     runWorkerTextStream.mockReset()
+  })
+
+  it('streams benign text without suppression', async () => {
+    runWorkerTextStream.mockImplementationOnce(() =>
+      mockStream([
+        { type: 'text-delta', textDelta: 'hello' },
+        { type: 'text-delta', textDelta: ' world' },
+      ])
+    )
+
+    const { handleChatStreaming } = await import('./streaming.js')
+    const { response, chunks } = makeResponse()
+
+    await handleChatStreaming(response as never, 'gpt-5.3-codex', 'hello')
+
+    expect(streamedContent(chunks)).toBe('hello world')
+    expect(chunks.join('')).not.toContain('suppressed')
+  })
+
+  it('streams benign JSON-like text that is not a tool call payload', async () => {
+    const jsonText = '{"status":"ok","message":"normal structured explanation"}'
+    runWorkerTextStream.mockImplementationOnce(() =>
+      mockStream([{ type: 'text-delta', textDelta: jsonText }])
+    )
+
+    const { handleChatStreaming } = await import('./streaming.js')
+    const { response, chunks } = makeResponse()
+
+    await handleChatStreaming(response as never, 'gpt-5.3-codex', 'hello')
+
+    expect(streamedContent(chunks)).toBe(jsonText)
+    expect(chunks.join('')).not.toContain('suppressed')
+  })
+
+  it('does not suppress prose that mentions tool-call-shaped JSON later in the text', async () => {
+    const text = 'Example JSON: {"name":"lookup","arguments":{"query":"weather"}}'
+    runWorkerTextStream.mockImplementationOnce(() =>
+      mockStream([{ type: 'text-delta', textDelta: text }])
+    )
+
+    const { handleChatStreaming } = await import('./streaming.js')
+    const { response, chunks } = makeResponse()
+
+    await handleChatStreaming(response as never, 'gpt-5.3-codex', 'hello')
+
+    expect(streamedContent(chunks)).toBe(text)
+    expect(chunks.join('')).not.toContain('suppressed')
+  })
+
+  it('suppresses tool-call-shaped JSON split across chunk boundaries', async () => {
+    runWorkerTextStream.mockImplementationOnce(() =>
+      mockStream([
+        { type: 'text-delta', textDelta: '{"na' },
+        { type: 'text-delta', textDelta: 'me":"lookup","arg' },
+        { type: 'text-delta', textDelta: 'uments":{"query":"secret"}}' },
+      ])
+    )
+
+    const { handleChatStreaming } = await import('./streaming.js')
+    const { response, chunks } = makeResponse()
+
+    await handleChatStreaming(response as never, 'gpt-5.3-codex', 'hello')
+
+    expect(streamedContent(chunks)).toBe(
+      'Model output suppressed because it resembled a tool call payload.'
+    )
+    expect(chunks.join('')).not.toContain('lookup')
+    expect(chunks.join('')).not.toContain('secret')
+  })
+
+  it('suppresses tool_calls payloads before streaming raw tool details', async () => {
+    runWorkerTextStream.mockImplementationOnce(() =>
+      mockStream([
+        { type: 'text-delta', textDelta: '{"tool_' },
+        { type: 'text-delta', textDelta: 'calls":[{"function":{"name":"lookup"}}]}' },
+      ])
+    )
+
+    const { handleChatStreaming } = await import('./streaming.js')
+    const { response, chunks } = makeResponse()
+
+    await handleChatStreaming(response as never, 'gpt-5.3-codex', 'hello')
+
+    expect(streamedContent(chunks)).toBe(
+      'Model output suppressed because it resembled a tool call payload.'
+    )
+    expect(chunks.join('')).not.toContain('tool_calls')
+    expect(chunks.join('')).not.toContain('lookup')
+  })
+
+  it('flushes incomplete malformed JSON-like text without throwing when it is not tool-shaped', async () => {
+    const malformed = '{"status":"ok"'
+    runWorkerTextStream.mockImplementationOnce(() =>
+      mockStream([{ type: 'text-delta', textDelta: malformed }])
+    )
+
+    const { handleChatStreaming } = await import('./streaming.js')
+    const { response, chunks } = makeResponse()
+
+    await handleChatStreaming(response as never, 'gpt-5.3-codex', 'hello')
+
+    expect(streamedContent(chunks)).toBe(malformed)
+    expect(response.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('streams refusal text normally', async () => {
+    const refusal = "I can't help with that request."
+    runWorkerTextStream.mockImplementationOnce(() =>
+      mockStream([{ type: 'text-delta', textDelta: refusal }])
+    )
+
+    const { handleChatStreaming } = await import('./streaming.js')
+    const { response, chunks } = makeResponse()
+
+    await handleChatStreaming(response as never, 'gpt-5.3-codex', 'hello')
+
+    expect(streamedContent(chunks)).toBe(refusal)
+    expect(response.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back before content and keeps a single model in emitted chunks', async () => {
     runWorkerTextStream
       .mockImplementationOnce(() =>
         mockStream([
@@ -81,7 +209,6 @@ describe('handleChatStreaming', () => {
   })
 
   it('does not fallback when policy error happens after content is emitted', async () => {
-    runWorkerTextStream.mockReset()
     runWorkerTextStream.mockImplementationOnce(() =>
       mockStream([
         { type: 'text-delta', textDelta: 'partial' },

--- a/src/chat/streaming.ts
+++ b/src/chat/streaming.ts
@@ -1,14 +1,18 @@
 import type { Response } from 'express'
-import { runWorkerTextStream } from '../ollama.js'
-import { nowSeconds, openAICompletionId } from './responseBuilders.js'
 import { getPolicyFallbackModel } from '../ai/modelPolicy.js'
 import { parsePolicySignal } from '../ai/policySignal.js'
 import { log } from '../log.js'
+import { runWorkerTextStream } from '../ollama.js'
+import { nowSeconds, openAICompletionId } from './responseBuilders.js'
 
 type StreamDeltaEvent = {
   type: 'text-delta'
   textDelta: string
 }
+
+const MAX_STRUCTURED_GATE_BUFFER_CHARS = 8192
+const SUPPRESSED_TOOL_PAYLOAD_MESSAGE =
+  'Model output suppressed because it resembled a tool call payload.'
 
 function sendSSEChunk(res: Response, chunk: unknown): void {
   res.write(`data: ${JSON.stringify(chunk)}\n\n`)
@@ -21,6 +25,186 @@ function isTextDeltaEvent(part: unknown): part is StreamDeltaEvent {
     (part as { type?: unknown }).type === 'text-delta' &&
     typeof (part as { textDelta?: unknown }).textDelta === 'string'
   )
+}
+
+type JsonCandidate = { kind: 'none' } | { kind: 'pending' } | { kind: 'json'; text: string }
+
+function getLeadingJsonCandidate(buffer: string): JsonCandidate {
+  const trimmedStart = buffer.trimStart()
+
+  if (!trimmedStart) {
+    return { kind: 'pending' }
+  }
+
+  let candidate = trimmedStart
+
+  if (candidate.startsWith('```')) {
+    const fenceLineEnd = candidate.indexOf('\n')
+    if (fenceLineEnd === -1) {
+      return { kind: 'pending' }
+    }
+
+    candidate = candidate.slice(fenceLineEnd + 1).trimStart()
+
+    if (!candidate) {
+      return { kind: 'pending' }
+    }
+  }
+
+  if (!candidate.startsWith('{') && !candidate.startsWith('[')) {
+    return { kind: 'none' }
+  }
+
+  return { kind: 'json', text: candidate }
+}
+
+function parseJsonStringEnd(text: string, start: number): number | null {
+  for (let index = start + 1; index < text.length; index += 1) {
+    const char = text[index]
+    if (char === '\\') {
+      index += 1
+      continue
+    }
+    if (char === '"') {
+      return index + 1
+    }
+  }
+
+  return null
+}
+
+function collectTopLevelObjectKeys(text: string): Set<string> {
+  const keys = new Set<string>()
+  if (!text.startsWith('{')) {
+    return keys
+  }
+
+  let index = 1
+  while (index < text.length) {
+    while (/\s|,/.test(text[index] ?? '')) {
+      index += 1
+    }
+
+    if (text[index] === '}') {
+      break
+    }
+
+    if (text[index] !== '"') {
+      break
+    }
+
+    const keyEnd = parseJsonStringEnd(text, index)
+    if (keyEnd === null) {
+      break
+    }
+
+    let colonIndex = keyEnd
+    while (/\s/.test(text[colonIndex] ?? '')) {
+      colonIndex += 1
+    }
+
+    if (text[colonIndex] !== ':') {
+      break
+    }
+
+    try {
+      keys.add(JSON.parse(text.slice(index, keyEnd)) as string)
+    } catch {
+      break
+    }
+
+    index = colonIndex + 1
+    const stack: string[] = []
+    let inString = false
+
+    while (index < text.length) {
+      const char = text[index]
+
+      if (inString) {
+        if (char === '\\') {
+          index += 2
+          continue
+        }
+        if (char === '"') {
+          inString = false
+        }
+        index += 1
+        continue
+      }
+
+      if (char === '"') {
+        inString = true
+        index += 1
+        continue
+      }
+
+      if (char === '{' || char === '[') {
+        stack.push(char === '{' ? '}' : ']')
+      } else if ((char === '}' || char === ']') && stack.at(-1) === char) {
+        stack.pop()
+      } else if (stack.length === 0 && (char === ',' || char === '}')) {
+        break
+      }
+
+      index += 1
+    }
+
+    if (keys.has('tool_calls') || (keys.has('name') && keys.has('arguments'))) {
+      break
+    }
+  }
+
+  return keys
+}
+
+function looksLikeToolCallPayload(text: string): boolean {
+  const keys = collectTopLevelObjectKeys(text)
+  return keys.has('tool_calls') || (keys.has('name') && keys.has('arguments'))
+}
+
+function findCompleteJsonEnd(text: string): number | null {
+  const stack: string[] = []
+  let inString = false
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]
+
+    if (inString) {
+      if (char === '\\') {
+        index += 1
+        continue
+      }
+      if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+      continue
+    }
+
+    if (char === '{' || char === '[') {
+      stack.push(char === '{' ? '}' : ']')
+      continue
+    }
+
+    if (char !== '}' && char !== ']') {
+      continue
+    }
+
+    if (stack.at(-1) !== char) {
+      return index + 1
+    }
+
+    stack.pop()
+    if (stack.length === 0) {
+      return index + 1
+    }
+  }
+
+  return null
 }
 
 export async function handleChatStreaming(
@@ -65,7 +249,6 @@ export async function handleChatStreaming(
     })
   }
 
-  const suppressionEnabled = process.env.STREAM_SUPPRESS_TOOLISH === '1'
   const pipeModelStream = async (activeModel: string): Promise<void> => {
     const streamResult = runWorkerTextStream({
       modelId: activeModel,
@@ -77,83 +260,12 @@ export async function handleChatStreaming(
       routeKind: 'chat',
     })
 
-    let gating = suppressionEnabled
+    let gating = true
     let preBuffer = ''
 
-    for await (const part of streamResult.fullStream) {
-      if (!isTextDeltaEvent(part)) {
-        continue
-      }
-
-      let delta = String(part.textDelta ?? '')
-      if (!delta) {
-        continue
-      }
-
-      if (suppressionEnabled) {
-        delta = delta.replace(/```/g, '')
-      }
-
-      if (gating) {
-        preBuffer += delta
-        const trimmed = preBuffer.trim()
-
-        if (trimmed.length > 220 || preBuffer.includes('\n') || !trimmed.startsWith('{')) {
-          gating = false
-          if (preBuffer) {
-            sendRoleChunk()
-            sendSSEChunk(res, {
-              id,
-              object: 'chat.completion.chunk',
-              created,
-              model: responseModel,
-              choices: [
-                {
-                  index: 0,
-                  delta: { content: preBuffer },
-                  finish_reason: null,
-                },
-              ],
-            })
-            emittedAnyContent = true
-          }
-          preBuffer = ''
-          continue
-        }
-
-        try {
-          const parsed = JSON.parse(trimmed) as Record<string, unknown>
-          const looksToolCall =
-            (typeof parsed.name === 'string' &&
-              Object.prototype.hasOwnProperty.call(parsed, 'arguments')) ||
-            Object.prototype.hasOwnProperty.call(parsed, 'tool_calls')
-
-          if (looksToolCall) {
-            gating = false
-            preBuffer = ''
-            sendRoleChunk()
-            sendSSEChunk(res, {
-              id,
-              object: 'chat.completion.chunk',
-              created,
-              model: responseModel,
-              choices: [
-                {
-                  index: 0,
-                  delta: {
-                    content: 'Model output suppressed because it resembled a tool call payload.',
-                  },
-                  finish_reason: null,
-                },
-              ],
-            })
-            emittedAnyContent = true
-          }
-        } catch {
-          // Wait for additional tokens while gating.
-        }
-
-        continue
+    const emitContent = (content: string): void => {
+      if (!content) {
+        return
       }
 
       sendRoleChunk()
@@ -165,12 +277,90 @@ export async function handleChatStreaming(
         choices: [
           {
             index: 0,
-            delta: { content: delta },
+            delta: { content },
             finish_reason: null,
           },
         ],
       })
       emittedAnyContent = true
+    }
+
+    const suppressToolPayload = (): void => {
+      gating = false
+      preBuffer = ''
+      emitContent(SUPPRESSED_TOOL_PAYLOAD_MESSAGE)
+    }
+
+    const inspectBufferedPrefix = (): void => {
+      const candidate = getLeadingJsonCandidate(preBuffer)
+
+      if (candidate.kind === 'pending') {
+        return
+      }
+
+      if (candidate.kind === 'none') {
+        gating = false
+        emitContent(preBuffer)
+        preBuffer = ''
+        return
+      }
+
+      if (looksLikeToolCallPayload(candidate.text)) {
+        suppressToolPayload()
+        return
+      }
+
+      const completeJsonEnd = findCompleteJsonEnd(candidate.text)
+      if (completeJsonEnd !== null) {
+        try {
+          JSON.parse(candidate.text.slice(0, completeJsonEnd))
+        } catch {
+          gating = false
+          emitContent(preBuffer)
+          preBuffer = ''
+          return
+        }
+
+        gating = false
+        emitContent(preBuffer)
+        preBuffer = ''
+        return
+      }
+
+      if (preBuffer.length > MAX_STRUCTURED_GATE_BUFFER_CHARS) {
+        gating = false
+        emitContent(preBuffer)
+        preBuffer = ''
+      }
+    }
+
+    for await (const part of streamResult.fullStream) {
+      if (!isTextDeltaEvent(part)) {
+        continue
+      }
+
+      const delta = String(part.textDelta ?? '')
+      if (!delta) {
+        continue
+      }
+
+      if (gating) {
+        preBuffer += delta
+        inspectBufferedPrefix()
+        continue
+      }
+
+      emitContent(delta)
+    }
+
+    if (gating && preBuffer) {
+      const candidate = getLeadingJsonCandidate(preBuffer)
+      if (candidate.kind === 'json' && looksLikeToolCallPayload(candidate.text)) {
+        suppressToolPayload()
+        return
+      }
+
+      emitContent(preBuffer)
     }
   }
 


### PR DESCRIPTION
Closes #5

## Summary
- Replaces fragile partial JSON parsing with deterministic prefix buffering/classification for streamed output.
- Suppresses leading tool-call-shaped JSON payloads before raw tool details are streamed.
- Preserves normal streaming for benign text, benign JSON-like text, malformed non-tool JSON, refusal text, and fallback/error behavior.

## Ownership Boundary
- Chat streaming output gating only.
- Files touched: `src/chat/streaming.ts`, `src/chat/streaming.test.ts`.

## Dependency Confirmation
- Based on current `origin/main` at `d71c86e`.
- Wave 1 PRs #169 and #170 are merged.

## Tests Run
- `pnpm exec vitest run src/chat/streaming.test.ts`
- `pnpm exec biome check src/chat/streaming.ts src/chat/streaming.test.ts`
- `pnpm run build`
- Push hook: `pnpm run format:branch:check`

## Out Of Scope
- Command/path safety for #98.
- Config/startup validation.
- Metrics, execution routes, log explainer behavior, and broad route rewrites.

## Review Notes
- Suppression is now always active for leading raw tool-call-shaped JSON. This intentionally removes the prior env-gated behavior to make output safety deterministic.
- Leading raw JSON with top-level `tool_calls`, or both top-level `name` and `arguments`, is treated as tool-call-shaped even if a caller wanted that exact schema as benign text.
