### PR TITLE
feat(issue-14): expose per-model latency and failure metrics

### DIFF
--- a/src/http/metrics.test.ts
+++ b/src/http/metrics.test.ts
@@ -1,8 +1,8 @@
 import express from 'express'
 import request from 'supertest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { recordLlmRequest, renderPrometheusMetrics, resetHttpMetrics } from './metrics.js'
 import { requestLoggingMiddleware } from './requestLogging.js'
-import { renderPrometheusMetrics, resetHttpMetrics } from './metrics.js'
 
 describe('http metrics', () => {
   beforeEach(() => {
@@ -54,5 +54,19 @@ describe('http metrics', () => {
       'blackice_http_requests_total{route="/__unmatched__",method="GET",status="404"} 1'
     )
     expect(output).not.toContain('/does-not-exist/123')
+  })
+
+  it('exports LLM request counters and latency histograms by model and status', () => {
+    recordLlmRequest('qwen2.5:14b', 'success', 125)
+    recordLlmRequest('qwen2.5:14b', 'failure', 250)
+
+    const output = renderPrometheusMetrics()
+
+    expect(output).toContain('# TYPE llm_request_total counter')
+    expect(output).toContain('# TYPE llm_request_latency_seconds histogram')
+    expect(output).toContain('llm_request_total{model="qwen2.5:14b",status="success"} 1')
+    expect(output).toContain('llm_request_total{model="qwen2.5:14b",status="failure"} 1')
+    expect(output).toContain('llm_request_latency_seconds_bucket{model="qwen2.5:14b",le="+Inf"} 2')
+    expect(output).toContain('llm_request_latency_seconds_count{model="qwen2.5:14b"} 2')
   })
 })

--- a/src/http/metrics.ts
+++ b/src/http/metrics.ts
@@ -8,6 +8,7 @@ type CounterKey = RequestMetricKey & {
 }
 
 const HISTOGRAM_BUCKETS_MS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]
+const LLM_HISTOGRAM_BUCKETS_SECONDS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60]
 export const HTTP_METRICS_PENDING_ROUTE = '/__pending__'
 export const HTTP_METRICS_UNMATCHED_ROUTE = '/__unmatched__'
 
@@ -16,6 +17,10 @@ const durationSums = new Map<string, number>()
 const durationCounts = new Map<string, number>()
 const durationBuckets = new Map<string, number[]>()
 const inflightRequests = new Map<string, number>()
+const llmRequestCounters = new Map<string, number>()
+const llmDurationSums = new Map<string, number>()
+const llmDurationCounts = new Map<string, number>()
+const llmDurationBuckets = new Map<string, number[]>()
 
 function escapeLabelValue(value: string): string {
   return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', '\\n')
@@ -33,6 +38,14 @@ function counterKey(route: string, method: string, status: string): string {
   return metricKey([route, method, status])
 }
 
+function llmKey(model: string, status: string): string {
+  return metricKey([model, status])
+}
+
+function llmModelKey(model: string): string {
+  return metricKey([model])
+}
+
 function getHistogramBucketCounts(route: string, method: string): number[] {
   const key = routeKey(route, method)
   const existing = durationBuckets.get(key)
@@ -45,6 +58,18 @@ function getHistogramBucketCounts(route: string, method: string): number[] {
   return created
 }
 
+function getLlmHistogramBucketCounts(model: string): number[] {
+  const key = llmModelKey(model)
+  const existing = llmDurationBuckets.get(key)
+  if (existing) {
+    return existing
+  }
+
+  const created = Array.from({ length: LLM_HISTOGRAM_BUCKETS_SECONDS.length }, () => 0)
+  llmDurationBuckets.set(key, created)
+  return created
+}
+
 function parseCounterKey(key: string): CounterKey {
   const [route, method, status] = key.split('\u0000')
   return { route, method, status }
@@ -53,6 +78,16 @@ function parseCounterKey(key: string): CounterKey {
 function parseRouteKey(key: string): RequestMetricKey {
   const [route, method] = key.split('\u0000')
   return { route, method }
+}
+
+function parseLlmKey(key: string): { model: string; status: string } {
+  const [model, status] = key.split('\u0000')
+  return { model, status }
+}
+
+function parseLlmModelKey(key: string): { model: string } {
+  const [model] = key.split('\u0000')
+  return { model }
 }
 
 export function beginHttpRequest(route: string): void {
@@ -90,6 +125,28 @@ export function endHttpRequest(route: string): void {
     return
   }
   inflightRequests.set(route, current - 1)
+}
+
+export function recordLlmRequest(
+  model: string,
+  status: 'success' | 'failure',
+  latencyMs: number
+): void {
+  const normalizedModel = model.trim() || '<unknown>'
+  const latencySeconds = Math.max(0, latencyMs) / 1000
+  const requestKey = llmKey(normalizedModel, status)
+  llmRequestCounters.set(requestKey, (llmRequestCounters.get(requestKey) ?? 0) + 1)
+
+  const modelMetricKey = llmModelKey(normalizedModel)
+  llmDurationSums.set(modelMetricKey, (llmDurationSums.get(modelMetricKey) ?? 0) + latencySeconds)
+  llmDurationCounts.set(modelMetricKey, (llmDurationCounts.get(modelMetricKey) ?? 0) + 1)
+
+  const bucketCounts = getLlmHistogramBucketCounts(normalizedModel)
+  for (const [index, bucket] of LLM_HISTOGRAM_BUCKETS_SECONDS.entries()) {
+    if (latencySeconds <= bucket) {
+      bucketCounts[index] += 1
+    }
+  }
 }
 
 export function renderPrometheusMetrics(): string {
@@ -147,6 +204,46 @@ export function renderPrometheusMetrics(): string {
     )
   }
 
+  lines.push(
+    '# HELP llm_request_total Total LLM requests by model and status.',
+    '# TYPE llm_request_total counter'
+  )
+
+  const sortedLlmCounterEntries = [...llmRequestCounters.entries()].sort(([a], [b]) =>
+    a.localeCompare(b)
+  )
+  for (const [key, value] of sortedLlmCounterEntries) {
+    const { model, status } = parseLlmKey(key)
+    lines.push(
+      `llm_request_total{model="${escapeLabelValue(model)}",status="${escapeLabelValue(status)}"} ${value}`
+    )
+  }
+
+  lines.push(
+    '# HELP llm_request_latency_seconds LLM request latency histogram in seconds.',
+    '# TYPE llm_request_latency_seconds histogram'
+  )
+
+  const sortedLlmDurationEntries = [...llmDurationCounts.entries()].sort(([a], [b]) =>
+    a.localeCompare(b)
+  )
+  for (const [key, count] of sortedLlmDurationEntries) {
+    const { model } = parseLlmModelKey(key)
+    const bucketCounts = getLlmHistogramBucketCounts(model)
+    for (const [index, bucket] of LLM_HISTOGRAM_BUCKETS_SECONDS.entries()) {
+      lines.push(
+        `llm_request_latency_seconds_bucket{model="${escapeLabelValue(model)}",le="${bucket}"} ${bucketCounts[index]}`
+      )
+    }
+    lines.push(
+      `llm_request_latency_seconds_bucket{model="${escapeLabelValue(model)}",le="+Inf"} ${count}`
+    )
+    lines.push(
+      `llm_request_latency_seconds_sum{model="${escapeLabelValue(model)}"} ${(llmDurationSums.get(key) ?? 0).toFixed(6)}`
+    )
+    lines.push(`llm_request_latency_seconds_count{model="${escapeLabelValue(model)}"} ${count}`)
+  }
+
   return `${lines.join('\n')}\n`
 }
 
@@ -156,4 +253,8 @@ export function resetHttpMetrics(): void {
   durationCounts.clear()
   durationBuckets.clear()
   inflightRequests.clear()
+  llmRequestCounters.clear()
+  llmDurationSums.clear()
+  llmDurationCounts.clear()
+  llmDurationBuckets.clear()
 }

--- a/src/ollama.test.ts
+++ b/src/ollama.test.ts
@@ -78,6 +78,101 @@ describe('runWorkerText policy fallback', () => {
     expect(mocks.generateText).toHaveBeenCalledTimes(1)
   })
 
+  it('records LLM metrics for successful non-stream requests', async () => {
+    mocks.generateText.mockResolvedValueOnce({ text: 'ok' })
+
+    const { resetHttpMetrics, renderPrometheusMetrics } = await import('./http/metrics.js')
+    resetHttpMetrics()
+    const { runWorkerText } = await import('./ollama.js')
+
+    await expect(
+      runWorkerText({
+        modelId: 'qwen2.5:14b',
+        input: 'hello world',
+        routeKind: 'chat',
+      })
+    ).resolves.toEqual({ text: 'ok' })
+
+    const metrics = renderPrometheusMetrics()
+    expect(metrics).toContain('llm_request_total{model="qwen2.5:14b",status="success"} 1')
+    expect(metrics).toContain('llm_request_latency_seconds_count{model="qwen2.5:14b"} 1')
+  })
+
+  it('records LLM metrics for failed non-stream requests', async () => {
+    mocks.generateText.mockRejectedValueOnce(new Error('network down'))
+
+    const { resetHttpMetrics, renderPrometheusMetrics } = await import('./http/metrics.js')
+    resetHttpMetrics()
+    const { runWorkerText } = await import('./ollama.js')
+
+    await expect(
+      runWorkerText({
+        modelId: 'qwen2.5:14b',
+        input: 'hello world',
+        routeKind: 'chat',
+      })
+    ).rejects.toThrow('network down')
+
+    const metrics = renderPrometheusMetrics()
+    expect(metrics).toContain('llm_request_total{model="qwen2.5:14b",status="failure"} 1')
+    expect(metrics).toContain('llm_request_latency_seconds_count{model="qwen2.5:14b"} 1')
+  })
+
+  it('records LLM metrics after stream consumption completes', async () => {
+    mocks.streamText.mockReturnValueOnce({
+      fullStream: (async function* stream() {
+        yield { type: 'text-delta', textDelta: 'ok' }
+      })(),
+    })
+
+    const { resetHttpMetrics, renderPrometheusMetrics } = await import('./http/metrics.js')
+    resetHttpMetrics()
+    const { runWorkerTextStream } = await import('./ollama.js')
+
+    const result = runWorkerTextStream({
+      modelId: 'qwen2.5:14b',
+      input: 'hello world',
+      routeKind: 'chat',
+    })
+
+    for await (const _part of result.fullStream) {
+      // Consume the stream so completion can be observed.
+    }
+
+    const metrics = renderPrometheusMetrics()
+    expect(metrics).toContain('llm_request_total{model="qwen2.5:14b",status="success"} 1')
+    expect(metrics).toContain('llm_request_latency_seconds_count{model="qwen2.5:14b"} 1')
+  })
+
+  it('records LLM metrics when stream consumption fails', async () => {
+    mocks.streamText.mockReturnValueOnce({
+      fullStream: (async function* stream() {
+        yield { type: 'text-delta', textDelta: 'before failure' }
+        throw new Error('stream failed')
+      })(),
+    })
+
+    const { resetHttpMetrics, renderPrometheusMetrics } = await import('./http/metrics.js')
+    resetHttpMetrics()
+    const { runWorkerTextStream } = await import('./ollama.js')
+
+    const result = runWorkerTextStream({
+      modelId: 'qwen2.5:14b',
+      input: 'hello world',
+      routeKind: 'chat',
+    })
+
+    await expect(async () => {
+      for await (const _part of result.fullStream) {
+        // Consume the stream so failure can be observed.
+      }
+    }).rejects.toThrow('stream failed')
+
+    const metrics = renderPrometheusMetrics()
+    expect(metrics).toContain('llm_request_total{model="qwen2.5:14b",status="failure"} 1')
+    expect(metrics).toContain('llm_request_latency_seconds_count{model="qwen2.5:14b"} 1')
+  })
+
   it('checks model availability against Ollama tags', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -1,11 +1,12 @@
 import { generateText, streamText } from 'ai'
 import { createOllama } from 'ollama-ai-provider-v2'
-import { buildWorkerContractPrompt, sanitizeLLMOutput } from './sanitize.js'
-import { env } from './config/env.js'
-import { getRuntimeConfig } from './config/runtimeConfig.js'
 import { getPolicyFallbackModel } from './ai/modelPolicy.js'
 import { parsePolicySignal } from './ai/policySignal.js'
+import { env } from './config/env.js'
+import { getRuntimeConfig } from './config/runtimeConfig.js'
+import { recordLlmRequest } from './http/metrics.js'
 import { log } from './log.js'
+import { buildWorkerContractPrompt, sanitizeLLMOutput } from './sanitize.js'
 
 function normalizeOllamaBaseURL(input: string): string {
   const trimmed = input.trim().replace(/\/+$/, '')
@@ -75,6 +76,18 @@ export class ModelAvailabilityCheckError extends Error {
 function resolveRequestedModel(requestedModel?: string): string {
   const trimmed = requestedModel?.trim()
   return trimmed && trimmed.length > 0 ? trimmed : configuredModel
+}
+
+function nowMs(): number {
+  return Date.now()
+}
+
+function recordLlmSuccess(modelId: string, startedAt: number): void {
+  recordLlmRequest(modelId, 'success', nowMs() - startedAt)
+}
+
+function recordLlmFailure(modelId: string, startedAt: number): void {
+  recordLlmRequest(modelId, 'failure', nowMs() - startedAt)
 }
 
 function toModelAvailabilityError(error: unknown): ModelAvailabilityCheckError {
@@ -170,20 +183,28 @@ async function generateWithModel(params: {
   }
 
   const model = resolveModel(params.modelId) as Parameters<typeof generateText>[0]['model']
-  const result = await generateText({
-    model,
-    prompt: params.prompt,
-    temperature: params.temperature,
-    maxOutputTokens: params.maxTokens,
-    headers: Object.keys(headers).length > 0 ? headers : undefined,
-  })
+  const startedAt = nowMs()
 
-  const sanitized = sanitizeLLMOutput(result.text)
-  if (!sanitized.ok) {
-    throw new Error(sanitized.error)
+  try {
+    const result = await generateText({
+      model,
+      prompt: params.prompt,
+      temperature: params.temperature,
+      maxOutputTokens: params.maxTokens,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+    })
+
+    const sanitized = sanitizeLLMOutput(result.text)
+    if (!sanitized.ok) {
+      throw new Error(sanitized.error)
+    }
+
+    recordLlmSuccess(params.modelId, startedAt)
+    return { text: sanitized.text }
+  } catch (error: unknown) {
+    recordLlmFailure(params.modelId, startedAt)
+    throw error
   }
-
-  return { text: sanitized.text }
 }
 
 export async function runWorkerText(params: GenerateParams): Promise<{ text: string }> {
@@ -269,14 +290,35 @@ export function runWorkerTextStream(params: GenerateParams) {
     headers['X-Safety-Identifier'] = params.safetyIdentifier
   }
   const model = resolveModel(params.modelId) as Parameters<typeof streamText>[0]['model']
+  const startedAt = nowMs()
 
-  return streamText({
-    model,
-    prompt,
-    temperature: params.temperature,
-    maxOutputTokens: params.maxTokens,
-    headers: Object.keys(headers).length > 0 ? headers : undefined,
-  })
+  try {
+    const streamResult = streamText({
+      model,
+      prompt,
+      temperature: params.temperature,
+      maxOutputTokens: params.maxTokens,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+    })
+
+    return {
+      ...streamResult,
+      fullStream: (async function* observeFullStream() {
+        try {
+          for await (const part of streamResult.fullStream) {
+            yield part
+          }
+          recordLlmSuccess(params.modelId, startedAt)
+        } catch (error: unknown) {
+          recordLlmFailure(params.modelId, startedAt)
+          throw error
+        }
+      })(),
+    }
+  } catch (error: unknown) {
+    recordLlmFailure(params.modelId, startedAt)
+    throw error
+  }
 }
 
 export { baseURL as ollamaBaseURL }


### PR DESCRIPTION
Closes #14

## Summary
- Adds Prometheus-compatible LLM request metrics to the existing in-memory metrics renderer.
- Exposes `llm_request_total` labeled by `model` and `status`.
- Exposes `llm_request_latency_seconds` histogram labeled by `model`.
- Instruments centralized Ollama non-stream and stream helpers so callers do not duplicate metrics logic.

## Ownership Boundary
- Metrics and LLM request instrumentation only.
- Files touched: `src/http/metrics.ts`, `src/http/metrics.test.ts`, `src/ollama.ts`, `src/ollama.test.ts`.

## Dependency Confirmation
- Based on current `origin/main` at `a56b1a9` after Wave 2 PRs #171 and #172 merged.
- No dependency on held issues #13, #15, or #128.

## Tests Run
- `pnpm exec biome check src/http/metrics.ts src/http/metrics.test.ts src/ollama.ts src/ollama.test.ts`
- `pnpm exec vitest run src/http/metrics.test.ts src/ollama.test.ts`
- `pnpm run build`
- Push hook: `pnpm run format:branch:check`

## Out Of Scope
- Token usage metrics.
- Dashboard/Grafana wiring.
- LLM response caching for #13.
- Eval harness work for #15.
- Changes to routing, execution, log explainer behavior, command/path safety, or startup config.

## Review Notes
- Stream metrics are recorded when `fullStream` is consumed to completion or throws. If a caller creates a stream and never consumes it, no completion/failure observation is recorded.
- Fallback attempts are counted as separate model requests, so a primary model policy failure plus fallback success records one failure for the primary and one success for the fallback.
