### PR TITLE
fix(issue-175): harden production config and secret validation

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -38,6 +38,8 @@ const DEFAULT_EXECUTION_PREFLIGHT_MAX_AGE_SECONDS = 300
 const DEFAULT_EXECUTION_SIGNER_KIND = 'mock'
 const DEFAULT_EXECUTION_STORAGE_KIND = 'memory'
 const DEFAULT_EXECUTION_STORAGE_PATH = ''
+const PRODUCTION_RUNTIME_ENV = 'production'
+const SAFE_PRODUCTION_AUTH_EXEMPT_PATHS = new Set(['/healthz', '/readyz', '/version'])
 
 function clampInt(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value))
@@ -201,6 +203,76 @@ function formatValidationIssues(error: z.ZodError): string {
   return error.issues.map((issue) => `${formatIssuePath(issue)}: ${issue.message}`).join('; ')
 }
 
+function normalizeExemptPath(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed === '/') {
+    return trimmed
+  }
+  return trimmed.replace(/\/+$/, '') || '/'
+}
+
+function parseAuthExemptPaths(value: string | undefined): string[] {
+  return String(value ?? '/healthz,/readyz,/version')
+    .split(',')
+    .map(normalizeExemptPath)
+    .filter(Boolean)
+}
+
+function isProductionRuntime(): boolean {
+  return (
+    String(process.env.BLACKICE_RUNTIME_ENV ?? '')
+      .trim()
+      .toLowerCase() === PRODUCTION_RUNTIME_ENV
+  )
+}
+
+function validateProductionRuntimeConfig(input: {
+  configFileRaw: string | undefined
+  yamlConfig: z.infer<typeof YamlConfigSchema>
+  runtimeConfig: RuntimeConfig
+}): void {
+  if (!isProductionRuntime()) {
+    return
+  }
+
+  const issues: string[] = []
+  const apiToken = String(process.env.API_TOKEN ?? '').trim()
+  if (!apiToken) {
+    issues.push('API_TOKEN: required when BLACKICE_RUNTIME_ENV=production')
+  }
+
+  if (!input.configFileRaw?.trim()) {
+    issues.push('BLACKICE_CONFIG_FILE: explicit config file is required in production')
+  }
+
+  const exemptPaths = parseAuthExemptPaths(process.env.AUTH_EXEMPT_PATHS)
+  const unsafeExemptPaths = exemptPaths.filter(
+    (entry) => !SAFE_PRODUCTION_AUTH_EXEMPT_PATHS.has(entry)
+  )
+  if (unsafeExemptPaths.length > 0) {
+    issues.push(
+      `AUTH_EXEMPT_PATHS: production exemptions may only include ${[
+        ...SAFE_PRODUCTION_AUTH_EXEMPT_PATHS,
+      ].join(', ')}`
+    )
+  }
+
+  const configuredStorageKind = input.yamlConfig.execution?.storageKind?.trim()
+  if (!configuredStorageKind) {
+    issues.push('execution.storageKind: explicit durable storage kind is required in production')
+  } else if (configuredStorageKind === 'memory') {
+    issues.push('execution.storageKind: memory storage is not allowed in production')
+  }
+
+  if (!input.runtimeConfig.execution.storagePath.trim()) {
+    issues.push('execution.storagePath: required for production durable storage')
+  }
+
+  if (issues.length > 0) {
+    throw new Error(`Invalid production configuration: ${issues.join('; ')}`)
+  }
+}
+
 function loadYamlConfig(filePath: string): z.infer<typeof YamlConfigSchema> {
   if (!existsSync(filePath)) {
     throw new Error(`Config file not found: ${filePath}`)
@@ -228,7 +300,8 @@ function loadYamlConfig(filePath: string): z.infer<typeof YamlConfigSchema> {
 let cachedRuntimeConfig: RuntimeConfig | null = null
 
 function loadRuntimeConfigFromEnv(): RuntimeConfig {
-  const configFileRaw = String(process.env.BLACKICE_CONFIG_FILE ?? DEFAULT_CONFIG_FILE).trim()
+  const configuredConfigFile = process.env.BLACKICE_CONFIG_FILE
+  const configFileRaw = String(configuredConfigFile ?? DEFAULT_CONFIG_FILE).trim()
   const configFile = path.resolve(configFileRaw)
   const yamlConfig = loadYamlConfig(configFile)
 
@@ -342,6 +415,12 @@ function loadRuntimeConfigFromEnv(): RuntimeConfig {
   if (!result.success) {
     throw new Error(`Invalid runtime config ${configFile}: ${formatValidationIssues(result.error)}`)
   }
+
+  validateProductionRuntimeConfig({
+    configFileRaw: configuredConfigFile,
+    yamlConfig,
+    runtimeConfig: result.data,
+  })
 
   return result.data
 }

--- a/src/runtimeConfig.test.ts
+++ b/src/runtimeConfig.test.ts
@@ -243,4 +243,69 @@ execution:
 
     expect(() => getRuntimeConfig()).toThrow(`Config file not found: ${configFile}`)
   })
+
+  it('requires auth and explicit config selection in production mode', async () => {
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    vi.stubEnv('BLACKICE_RUNTIME_ENV', 'production')
+
+    expect(() => getRuntimeConfig()).toThrow(/API_TOKEN: required/)
+    expect(() => getRuntimeConfig()).toThrow(/BLACKICE_CONFIG_FILE: explicit config file/)
+  })
+
+  it('rejects unsafe production auth exemptions without leaking secrets', async () => {
+    const configFile = writeConfig(`version: 1
+execution:
+  storageKind: file
+  storagePath: ./.tmp/prod-execution-state.json
+`)
+
+    vi.stubEnv('BLACKICE_RUNTIME_ENV', 'production')
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    vi.stubEnv('API_TOKEN', 'super-secret-token-value')
+    vi.stubEnv('AUTH_EXEMPT_PATHS', '/healthz,/metrics,/v1/models/check')
+
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(() => getRuntimeConfig()).toThrow(/AUTH_EXEMPT_PATHS:/)
+    expect(() => getRuntimeConfig()).not.toThrow(/super-secret-token-value/)
+  })
+
+  it('rejects implicit or memory execution storage in production mode', async () => {
+    const configFile = writeConfig(`version: 1
+execution:
+  storageKind: memory
+`)
+
+    vi.stubEnv('BLACKICE_RUNTIME_ENV', 'production')
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    vi.stubEnv('API_TOKEN', 'super-secret-token-value')
+
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(() => getRuntimeConfig()).toThrow(/execution\.storageKind: memory storage/)
+    expect(() => getRuntimeConfig()).toThrow(/execution\.storagePath: required/)
+  })
+
+  it('allows production mode with safe auth exemptions and durable storage', async () => {
+    const configFile = writeConfig(`version: 1
+execution:
+  storageKind: file
+  storagePath: ./.tmp/prod-execution-state.json
+`)
+
+    vi.stubEnv('BLACKICE_RUNTIME_ENV', 'production')
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+    vi.stubEnv('API_TOKEN', 'super-secret-token-value')
+    vi.stubEnv('AUTH_EXEMPT_PATHS', '/healthz,/readyz,/version')
+
+    const { getRuntimeConfig } = await import('./config/runtimeConfig.js')
+
+    expect(getRuntimeConfig()).toMatchObject({
+      execution: {
+        storageKind: 'file',
+        storagePath: './.tmp/prod-execution-state.json',
+      },
+    })
+  })
 })


### PR DESCRIPTION
Closes #175

## Prod-Readiness Objective
Prevent accidental production startup with missing auth, unsafe auth exemptions, or non-durable execution storage.

## Summary
- Adds `BLACKICE_RUNTIME_ENV=production` validation inside runtime config loading.
- Requires explicit `BLACKICE_CONFIG_FILE` in production mode.
- Requires `API_TOKEN` in production mode without echoing secret values.
- Restricts production auth exemptions to `/healthz`, `/readyz`, and `/version`.
- Requires explicit non-memory execution storage and a storage path in production mode.

## Files Touched
- `src/config/runtimeConfig.ts`
- `src/runtimeConfig.test.ts`

## Tests Run
- `pnpm exec biome check src/config/runtimeConfig.ts src/runtimeConfig.test.ts`
- `pnpm exec vitest run src/runtimeConfig.test.ts src/startupPreflight.test.ts`
- `pnpm run build`
- Push hook: `pnpm run format:branch:check`

## Rollout Notes
- Production hardening is opt-in with `BLACKICE_RUNTIME_ENV=production`.
- Existing local/dev behavior is unchanged when `BLACKICE_RUNTIME_ENV` is unset.
- In production mode, `/metrics` should be accessed with auth rather than added to `AUTH_EXEMPT_PATHS`.

## Out Of Scope
- Durable storage parent/writability checks.
- Readiness route changes.
- Deployment runbook work.
