### PR TITLE
feat(issue-176): add durable storage readiness and recovery checks

### DIFF
--- a/src/execution/repository.test.ts
+++ b/src/execution/repository.test.ts
@@ -1,10 +1,15 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import type { IntentRecord } from './schema.js'
 import type { ExecutionLogRecord, PreflightRecord } from './contracts.js'
-import { FileExecutionRepository, InMemoryExecutionRepository } from './repository.js'
+import {
+  FileExecutionRepository,
+  InMemoryExecutionRepository,
+  checkExecutionRepositoryStorage,
+  createExecutionRepository,
+} from './repository.js'
+import type { IntentRecord } from './schema.js'
 
 const tempDirs: string[] = []
 
@@ -148,5 +153,45 @@ describe('execution repositories', () => {
     expect(persisted.idempotencyKeys[intent.idempotencyKey]).toBe(intent.intentId)
     expect(persisted.preflightRecords).toHaveLength(1)
     expect(persisted.executionLogs).toHaveLength(1)
+  })
+
+  it('checks storage parent availability before repository creation', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'blackice-exec-repo-'))
+    tempDirs.push(dir)
+    const missingParentPath = path.join(dir, 'missing-parent', 'execution-state.json')
+
+    await expect(
+      checkExecutionRepositoryStorage({
+        storageKind: 'file',
+        storagePath: missingParentPath,
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('execution storage parent'),
+    })
+    expect(() =>
+      createExecutionRepository({
+        storageKind: 'file',
+        storagePath: missingParentPath,
+      })
+    ).toThrow(/execution storage parent/)
+  })
+
+  it('reports corrupted storage state before use', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'blackice-exec-repo-'))
+    tempDirs.push(dir)
+    mkdirSync(dir, { recursive: true })
+    const storagePath = path.join(dir, 'execution-state.json')
+    writeFileSync(storagePath, '{not-valid-json', 'utf8')
+
+    await expect(
+      checkExecutionRepositoryStorage({
+        storageKind: 'file',
+        storagePath,
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('execution storage state is unreadable'),
+    })
   })
 })

--- a/src/execution/repository.ts
+++ b/src/execution/repository.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { constants, accessSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { access } from 'node:fs/promises'
 import path from 'node:path'
 import {
-  PreflightRecordSchema,
   type ExecutionLogRecord,
   type ExecutionRepository,
   type PreflightRecord,
+  PreflightRecordSchema,
 } from './contracts.js'
 import type { IntentRecord, IntentStatus } from './schema.js'
 import { AuditEventSchema, IntentRecordSchema } from './schema.js'
@@ -21,6 +22,13 @@ const EMPTY_STATE: StoredExecutionState = {
   idempotencyKeys: {},
   preflightRecords: [],
   executionLogs: [],
+}
+
+export type ExecutionRepositoryStorageCheck = {
+  ok: boolean
+  storageKind: string
+  storagePath?: string
+  reason?: string
 }
 
 function cloneIntent(intent: IntentRecord): IntentRecord {
@@ -220,7 +228,106 @@ export function createExecutionRepository(options: {
     throw new Error(`execution.storagePath is required for storageKind=${options.storageKind}`)
   }
 
+  const storageCheck = checkExecutionRepositoryStorageSync(options)
+  if (!storageCheck.ok) {
+    throw new Error(storageCheck.reason ?? 'execution repository storage is unavailable')
+  }
+
   return new FileExecutionRepository(options.storagePath)
+}
+
+export async function checkExecutionRepositoryStorage(options: {
+  storageKind: string
+  storagePath?: string
+}): Promise<ExecutionRepositoryStorageCheck> {
+  if (options.storageKind === 'memory') {
+    return { ok: true, storageKind: options.storageKind }
+  }
+
+  if (!options.storagePath) {
+    return {
+      ok: false,
+      storageKind: options.storageKind,
+      reason: `execution.storagePath is required for storageKind=${options.storageKind}`,
+    }
+  }
+
+  const storagePath = path.resolve(options.storagePath)
+  const parent = path.dirname(storagePath)
+  try {
+    await access(parent, constants.R_OK | constants.W_OK)
+  } catch {
+    return {
+      ok: false,
+      storageKind: options.storageKind,
+      storagePath,
+      reason: `execution storage parent is not readable and writable: ${parent}`,
+    }
+  }
+
+  if (!existsSync(storagePath)) {
+    return { ok: true, storageKind: options.storageKind, storagePath }
+  }
+
+  try {
+    parseState(readFileSync(storagePath, 'utf8'))
+    await access(storagePath, constants.R_OK | constants.W_OK)
+    return { ok: true, storageKind: options.storageKind, storagePath }
+  } catch (error) {
+    return {
+      ok: false,
+      storageKind: options.storageKind,
+      storagePath,
+      reason: `execution storage state is unreadable: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    }
+  }
+}
+
+function checkExecutionRepositoryStorageSync(options: {
+  storageKind: string
+  storagePath?: string
+}): ExecutionRepositoryStorageCheck {
+  if (options.storageKind === 'memory') {
+    return { ok: true, storageKind: options.storageKind }
+  }
+
+  if (!options.storagePath) {
+    return {
+      ok: false,
+      storageKind: options.storageKind,
+      reason: `execution.storagePath is required for storageKind=${options.storageKind}`,
+    }
+  }
+
+  const storagePath = path.resolve(options.storagePath)
+  const parent = path.dirname(storagePath)
+  try {
+    if (!existsSync(parent)) {
+      return {
+        ok: false,
+        storageKind: options.storageKind,
+        storagePath,
+        reason: `execution storage parent does not exist: ${parent}`,
+      }
+    }
+    accessSync(parent, constants.R_OK | constants.W_OK)
+    if (existsSync(storagePath)) {
+      accessSync(storagePath, constants.R_OK | constants.W_OK)
+      parseState(readFileSync(storagePath, 'utf8'))
+    }
+    return { ok: true, storageKind: options.storageKind, storagePath }
+  } catch (error) {
+    return {
+      ok: false,
+      storageKind: options.storageKind,
+      storagePath,
+      reason: `execution storage state is unreadable: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    }
+  }
 }
 
 function ensureRepositoryFile(filePath: string): void {

--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tempDirs: string[] = []
+
+function writeConfig(contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'blackice-readiness-'))
+  const file = path.join(dir, 'blackice.test.yaml')
+  writeFileSync(file, contents)
+  tempDirs.push(dir)
+  return file
+}
+
+function okFetch(): typeof fetch {
+  return vi.fn(async () => new Response(JSON.stringify({ models: [] }), { status: 200 })) as never
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+  vi.stubGlobal('fetch', okFetch())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('readiness storage checks', () => {
+  it('includes execution storage success in readiness output', async () => {
+    const storageDir = mkdtempSync(path.join(tmpdir(), 'blackice-readiness-storage-'))
+    tempDirs.push(storageDir)
+    const configFile = writeConfig(`version: 1
+execution:
+  storageKind: file
+  storagePath: ${JSON.stringify(path.join(storageDir, 'execution-state.json'))}
+`)
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+
+    const { checkReadiness } = await import('./readiness.js')
+
+    await expect(checkReadiness()).resolves.toMatchObject({
+      ok: true,
+      checks: {
+        executionStorage: {
+          ok: true,
+          storageKind: 'file',
+        },
+      },
+    })
+  })
+
+  it('marks readiness unready when durable storage parent is unavailable', async () => {
+    const configRoot = mkdtempSync(path.join(tmpdir(), 'blackice-readiness-storage-'))
+    tempDirs.push(configRoot)
+    const missingParentPath = path.join(configRoot, 'missing', 'execution-state.json')
+    const configFile = writeConfig(`version: 1
+execution:
+  storageKind: file
+  storagePath: ${JSON.stringify(missingParentPath)}
+`)
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+
+    const { checkReadiness } = await import('./readiness.js')
+
+    await expect(checkReadiness()).resolves.toMatchObject({
+      ok: false,
+      checks: {
+        executionStorage: {
+          ok: false,
+          reason: expect.stringContaining('execution storage parent'),
+        },
+      },
+    })
+  })
+
+  it('marks readiness unready when durable storage state is corrupted', async () => {
+    const storageDir = mkdtempSync(path.join(tmpdir(), 'blackice-readiness-storage-'))
+    tempDirs.push(storageDir)
+    mkdirSync(storageDir, { recursive: true })
+    const storagePath = path.join(storageDir, 'execution-state.json')
+    writeFileSync(storagePath, '{not-json', 'utf8')
+    const configFile = writeConfig(`version: 1
+execution:
+  storageKind: file
+  storagePath: ${JSON.stringify(storagePath)}
+`)
+    vi.stubEnv('BLACKICE_CONFIG_FILE', configFile)
+
+    const { checkReadiness } = await import('./readiness.js')
+
+    await expect(checkReadiness()).resolves.toMatchObject({
+      ok: false,
+      checks: {
+        executionStorage: {
+          ok: false,
+          reason: expect.stringContaining('execution storage state is unreadable'),
+        },
+      },
+    })
+  })
+})

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -1,4 +1,5 @@
 import { getRuntimeConfig } from './config/runtimeConfig.js'
+import { checkExecutionRepositoryStorage } from './execution/repository.js'
 import { ollamaBaseURL } from './ollama.js'
 
 const runtimeConfig = getRuntimeConfig()
@@ -16,6 +17,12 @@ export type ReadinessCheckResult = {
       baseUrl: string
       latencyMs?: number
       status?: number
+      reason?: string
+    }
+    executionStorage: {
+      ok: boolean
+      storageKind: string
+      storagePath?: string
       reason?: string
     }
   }
@@ -60,11 +67,17 @@ export async function checkReadiness(): Promise<ReadinessCheckResult> {
     clearTimeout(timeout)
   }
 
+  const executionStorageCheck = await checkExecutionRepositoryStorage({
+    storageKind: runtimeConfig.execution.storageKind,
+    storagePath: runtimeConfig.execution.storagePath,
+  })
+
   return {
-    ok: ollamaCheck.ok,
+    ok: ollamaCheck.ok && executionStorageCheck.ok,
     checks: {
       app: { ok: true },
       ollama: ollamaCheck,
+      executionStorage: executionStorageCheck,
     },
     ts: new Date().toISOString(),
   }


### PR DESCRIPTION
Closes #176

## Prod-Readiness Objective
Make durable execution state observable and fail readiness when configured storage is unavailable or corrupted.

## Summary
- Adds reusable execution repository storage health checks.
- Validates file-backed repository parent access before repository creation.
- Parses existing durable state during health checks to catch corrupted files.
- Adds execution storage status to `/readyz` output and overall readiness.
- Adds focused repository and readiness tests.

## Files Touched
- `src/execution/repository.ts`
- `src/execution/repository.test.ts`
- `src/readiness.ts`
- `src/readiness.test.ts`

## Tests Run
- `pnpm exec biome check src/execution/repository.ts src/execution/repository.test.ts src/readiness.ts src/readiness.test.ts`
- `pnpm exec vitest run src/execution/repository.test.ts src/execution/service.test.ts src/readiness.test.ts`
- `pnpm run build`
- Push hook: `pnpm run format:branch:check`

## Rollout Notes
- Memory storage remains valid for dev/local mode.
- File-backed storage now requires an existing readable/writable parent directory before repository creation.
- `/readyz` now includes `checks.executionStorage` and returns unready under strict readiness when durable storage is unavailable.

## Out Of Scope
- Execution lifecycle behavior changes.
- Background repair or migration of corrupted state.
- Alert metrics and runbook work.
