### PR TITLE
feat(issue-178): expose alert-ready operational metrics

### DIFF
--- a/src/execution/repository.ts
+++ b/src/execution/repository.ts
@@ -1,6 +1,7 @@
 import { constants, accessSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { access } from 'node:fs/promises'
 import path from 'node:path'
+import { recordRepositoryError } from '../http/metrics.js'
 import {
   type ExecutionLogRecord,
   type ExecutionRepository,
@@ -63,6 +64,16 @@ function parseState(raw: string): StoredExecutionState {
     ),
     executionLogs: structuredClone(parsed.executionLogs ?? []),
   }
+}
+
+function metricStorageKind(storageKind: string): 'memory' | 'file' | 'other' {
+  if (storageKind === 'memory') {
+    return 'memory'
+  }
+  if (storageKind === 'file' || storageKind === 'sqlite') {
+    return 'file'
+  }
+  return 'other'
 }
 
 export class InMemoryExecutionRepository implements ExecutionRepository {
@@ -208,11 +219,21 @@ export class FileExecutionRepository implements ExecutionRepository {
   }
 
   private readState(): StoredExecutionState {
-    return parseState(readFileSync(this.filePath, 'utf8'))
+    try {
+      return parseState(readFileSync(this.filePath, 'utf8'))
+    } catch (error) {
+      recordRepositoryError('read', 'file')
+      throw error
+    }
   }
 
   private writeState(state: StoredExecutionState): void {
-    writeFileSync(this.filePath, JSON.stringify(state, null, 2))
+    try {
+      writeFileSync(this.filePath, JSON.stringify(state, null, 2))
+    } catch (error) {
+      recordRepositoryError('write', 'file')
+      throw error
+    }
   }
 }
 
@@ -225,11 +246,13 @@ export function createExecutionRepository(options: {
   }
 
   if (!options.storagePath) {
+    recordRepositoryError('create', metricStorageKind(options.storageKind))
     throw new Error(`execution.storagePath is required for storageKind=${options.storageKind}`)
   }
 
   const storageCheck = checkExecutionRepositoryStorageSync(options)
   if (!storageCheck.ok) {
+    recordRepositoryError('create', metricStorageKind(options.storageKind))
     throw new Error(storageCheck.reason ?? 'execution repository storage is unavailable')
   }
 
@@ -257,6 +280,7 @@ export async function checkExecutionRepositoryStorage(options: {
   try {
     await access(parent, constants.R_OK | constants.W_OK)
   } catch {
+    recordRepositoryError('readiness_check', metricStorageKind(options.storageKind))
     return {
       ok: false,
       storageKind: options.storageKind,
@@ -274,6 +298,7 @@ export async function checkExecutionRepositoryStorage(options: {
     await access(storagePath, constants.R_OK | constants.W_OK)
     return { ok: true, storageKind: options.storageKind, storagePath }
   } catch (error) {
+    recordRepositoryError('readiness_check', metricStorageKind(options.storageKind))
     return {
       ok: false,
       storageKind: options.storageKind,

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { getRuntimeConfig } from '../config/runtimeConfig.js'
+import { recordExecutionLifecycle, recordPreflightResult } from '../http/metrics.js'
 import type {
   ExecutionAdapter,
   ExecutionLogRecord,
@@ -21,7 +22,6 @@ import {
 } from './executionAdapter.js'
 import { buildPreflightRecord, computePreflightPolicyFingerprint } from './preflight.js'
 import { createExecutionRepository } from './repository.js'
-import { createSigningAdapter } from './signing.js'
 import {
   type AuditEvent,
   AuditEventSchema,
@@ -30,6 +30,7 @@ import {
   IntentRecordSchema,
   type SubmitIntentRequest,
 } from './schema.js'
+import { createSigningAdapter } from './signing.js'
 
 export class ExecutionPolicyError extends Error {
   status = 422
@@ -136,6 +137,7 @@ export class ExecutionService {
 
     const normalizedRequest = this.normalizePreflightRequest(intent, record.request)
     if (!record.result.ok) {
+      recordExecutionLifecycle('preflight_gate', 'blocked', 'preflight_failed')
       throw new ExecutionPolicyError(
         `Latest preflight for intent ${intentId} did not pass`,
         'preflight_failed'
@@ -143,6 +145,7 @@ export class ExecutionService {
     }
 
     if (record.result.venue !== normalizedRequest.venue) {
+      recordExecutionLifecycle('preflight_gate', 'blocked', 'preflight_mismatch')
       throw new ExecutionPolicyError(
         `Latest preflight for intent ${intentId} does not match the current venue`,
         'preflight_mismatch'
@@ -151,6 +154,7 @@ export class ExecutionService {
 
     const expectedFingerprint = computePreflightPolicyFingerprint(normalizedRequest)
     if (record.policyFingerprint !== expectedFingerprint) {
+      recordExecutionLifecycle('preflight_gate', 'blocked', 'preflight_stale')
       throw new ExecutionPolicyError(
         `Latest preflight for intent ${intentId} no longer matches current policy`,
         'preflight_stale'
@@ -159,12 +163,14 @@ export class ExecutionService {
 
     const maxAgeMs = getRuntimeConfig().execution.preflightMaxAgeSeconds * 1000
     if (Date.parse(record.recordedAt) + maxAgeMs < this.now().getTime()) {
+      recordExecutionLifecycle('preflight_gate', 'blocked', 'preflight_stale')
       throw new ExecutionPolicyError(
         `Latest preflight for intent ${intentId} is stale`,
         'preflight_stale'
       )
     }
 
+    recordExecutionLifecycle('preflight_gate', 'allowed', 'ok')
     return record
   }
 
@@ -189,6 +195,7 @@ export class ExecutionService {
     })
 
     this.repository.appendPreflightRecord(record)
+    recordPreflightResult(record.result.ok ? 'pass' : 'fail')
     this.appendAuditEvent(intent, 'preflight_recorded', requestId, {
       preflightId: record.preflightId,
       preflightOk: record.result.ok,
@@ -282,9 +289,11 @@ export class ExecutionService {
       return intent
     }
     if (intent.status !== 'confirmed') {
+      recordExecutionLifecycle('preflight_gate', 'blocked', 'invalid_state')
       throw new IntentStateError(`Intent ${intentId} cannot execute from status ${intent.status}`)
     }
     if (Date.parse(intent.expiresAt) < this.now().getTime()) {
+      recordExecutionLifecycle('preflight_gate', 'blocked', 'intent_expired')
       throw new ExecutionPolicyError(
         `Intent ${intentId} expired before execution`,
         'intent_expired'
@@ -304,6 +313,7 @@ export class ExecutionService {
       signedRequest = await this.signingAdapter.signExecutionRequest(executionRequest)
       intent.signerRef = signedRequest.signerRef
       this.repository.saveIntent(intent)
+      recordExecutionLifecycle('signing', 'success', 'ok')
       this.appendAuditEvent(intent, 'signing_succeeded', requestId, {
         signerRef: signedRequest.signerRef,
       })
@@ -312,6 +322,7 @@ export class ExecutionService {
       intent.status = 'confirmed'
       intent.updatedAt = nowIso
       this.repository.saveIntent(intent)
+      recordExecutionLifecycle('signing', 'failure', 'adapter_error')
       this.appendAuditEvent(intent, 'signing_failed', requestId, {
         error: error instanceof Error ? error.message : String(error),
       })
@@ -329,6 +340,7 @@ export class ExecutionService {
       intent.status = 'confirmed'
       intent.updatedAt = nowIso
       this.repository.saveIntent(intent)
+      recordExecutionLifecycle('placement', 'failure', 'adapter_error')
       this.appendAuditEvent(intent, 'execution_failed', requestId, {
         error: error instanceof Error ? error.message : String(error),
       })
@@ -350,10 +362,16 @@ export class ExecutionService {
       return { intent }
     }
 
-    const executionLog = await this.executionAdapter.getOrderStatus(
-      latestOrder.externalOrderId,
-      requestId
-    )
+    let executionLog: ExecutionLogRecord | null
+    try {
+      executionLog = await this.executionAdapter.getOrderStatus(
+        latestOrder.externalOrderId,
+        requestId
+      )
+    } catch (error) {
+      recordExecutionLifecycle('refresh', 'failure', 'adapter_error')
+      throw error
+    }
     if (!executionLog) {
       return { intent }
     }
@@ -378,6 +396,7 @@ export class ExecutionService {
       return intent
     }
     if (intent.status === 'executed' || intent.status === 'execution_pending') {
+      recordExecutionLifecycle('cancel', 'blocked', 'invalid_state')
       throw new IntentStateError(
         `Intent ${intentId} cannot be cancelled from status ${intent.status}`
       )
@@ -387,6 +406,7 @@ export class ExecutionService {
     intent.status = 'cancelled'
     intent.cancelledAt = nowIso
     intent.updatedAt = nowIso
+    recordExecutionLifecycle('cancel', 'success', 'ok')
     this.appendAuditEvent(intent, 'intent_cancelled', requestId, {})
     this.repository.saveIntent(intent)
     return intent
@@ -523,6 +543,11 @@ export class ExecutionService {
     }
 
     this.repository.saveIntent(intent)
+    recordExecutionLifecycle(
+      mode === 'append' ? 'placement' : 'refresh',
+      normalizedExecutionLog.status,
+      'venue_status'
+    )
     this.appendAuditEvent(
       intent,
       mapExecutionLogToAuditEventType(normalizedExecutionLog.status),

--- a/src/http/metrics.test.ts
+++ b/src/http/metrics.test.ts
@@ -1,7 +1,14 @@
 import express from 'express'
 import request from 'supertest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { recordLlmRequest, renderPrometheusMetrics, resetHttpMetrics } from './metrics.js'
+import {
+  recordExecutionLifecycle,
+  recordLlmRequest,
+  recordPreflightResult,
+  recordRepositoryError,
+  renderPrometheusMetrics,
+  resetHttpMetrics,
+} from './metrics.js'
 import { requestLoggingMiddleware } from './requestLogging.js'
 
 describe('http metrics', () => {
@@ -68,5 +75,32 @@ describe('http metrics', () => {
     expect(output).toContain('llm_request_total{model="qwen2.5:14b",status="failure"} 1')
     expect(output).toContain('llm_request_latency_seconds_bucket{model="qwen2.5:14b",le="+Inf"} 2')
     expect(output).toContain('llm_request_latency_seconds_count{model="qwen2.5:14b"} 2')
+  })
+
+  it('exports bounded operational execution and repository metrics', () => {
+    recordPreflightResult('pass')
+    recordPreflightResult('fail')
+    recordExecutionLifecycle('preflight_gate', 'blocked', 'preflight_required')
+    recordExecutionLifecycle('placement', 'filled', 'venue_status')
+    recordRepositoryError('readiness_check', 'file')
+
+    const output = renderPrometheusMetrics()
+
+    expect(output).toContain('# TYPE blackice_preflight_total counter')
+    expect(output).toContain('blackice_preflight_total{outcome="pass"} 1')
+    expect(output).toContain('blackice_preflight_total{outcome="fail"} 1')
+    expect(output).toContain('# TYPE blackice_execution_lifecycle_total counter')
+    expect(output).toContain(
+      'blackice_execution_lifecycle_total{stage="preflight_gate",outcome="blocked",reason="preflight_required"} 1'
+    )
+    expect(output).toContain(
+      'blackice_execution_lifecycle_total{stage="placement",outcome="filled",reason="venue_status"} 1'
+    )
+    expect(output).toContain('# TYPE blackice_repository_errors_total counter')
+    expect(output).toContain(
+      'blackice_repository_errors_total{operation="readiness_check",storage_kind="file"} 1'
+    )
+    expect(output).not.toContain('request_id')
+    expect(output).not.toContain('marketId')
   })
 })

--- a/src/http/metrics.ts
+++ b/src/http/metrics.ts
@@ -21,6 +21,9 @@ const llmRequestCounters = new Map<string, number>()
 const llmDurationSums = new Map<string, number>()
 const llmDurationCounts = new Map<string, number>()
 const llmDurationBuckets = new Map<string, number[]>()
+const preflightCounters = new Map<string, number>()
+const executionLifecycleCounters = new Map<string, number>()
+const repositoryErrorCounters = new Map<string, number>()
 
 function escapeLabelValue(value: string): string {
   return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', '\\n')
@@ -44,6 +47,18 @@ function llmKey(model: string, status: string): string {
 
 function llmModelKey(model: string): string {
   return metricKey([model])
+}
+
+function preflightKey(outcome: 'pass' | 'fail'): string {
+  return metricKey([outcome])
+}
+
+function executionLifecycleKey(stage: string, outcome: string, reason: string): string {
+  return metricKey([stage, outcome, reason])
+}
+
+function repositoryErrorKey(operation: string, storageKind: string): string {
+  return metricKey([operation, storageKind])
 }
 
 function getHistogramBucketCounts(route: string, method: string): number[] {
@@ -88,6 +103,25 @@ function parseLlmKey(key: string): { model: string; status: string } {
 function parseLlmModelKey(key: string): { model: string } {
   const [model] = key.split('\u0000')
   return { model }
+}
+
+function parsePreflightKey(key: string): { outcome: string } {
+  const [outcome] = key.split('\u0000')
+  return { outcome }
+}
+
+function parseExecutionLifecycleKey(key: string): {
+  stage: string
+  outcome: string
+  reason: string
+} {
+  const [stage, outcome, reason] = key.split('\u0000')
+  return { stage, outcome, reason }
+}
+
+function parseRepositoryErrorKey(key: string): { operation: string; storageKind: string } {
+  const [operation, storageKind] = key.split('\u0000')
+  return { operation, storageKind }
 }
 
 export function beginHttpRequest(route: string): void {
@@ -147,6 +181,47 @@ export function recordLlmRequest(
       bucketCounts[index] += 1
     }
   }
+}
+
+export function recordPreflightResult(outcome: 'pass' | 'fail'): void {
+  const key = preflightKey(outcome)
+  preflightCounters.set(key, (preflightCounters.get(key) ?? 0) + 1)
+}
+
+export function recordExecutionLifecycle(
+  stage: 'preflight_gate' | 'signing' | 'placement' | 'refresh' | 'cancel',
+  outcome:
+    | 'allowed'
+    | 'blocked'
+    | 'success'
+    | 'failure'
+    | 'accepted'
+    | 'rejected'
+    | 'placed'
+    | 'filled'
+    | 'cancelled'
+    | 'failed',
+  reason:
+    | 'ok'
+    | 'preflight_required'
+    | 'preflight_failed'
+    | 'preflight_mismatch'
+    | 'preflight_stale'
+    | 'intent_expired'
+    | 'invalid_state'
+    | 'adapter_error'
+    | 'venue_status'
+): void {
+  const key = executionLifecycleKey(stage, outcome, reason)
+  executionLifecycleCounters.set(key, (executionLifecycleCounters.get(key) ?? 0) + 1)
+}
+
+export function recordRepositoryError(
+  operation: 'create' | 'read' | 'write' | 'readiness_check',
+  storageKind: 'memory' | 'file' | 'other'
+): void {
+  const key = repositoryErrorKey(operation, storageKind)
+  repositoryErrorCounters.set(key, (repositoryErrorCounters.get(key) ?? 0) + 1)
 }
 
 export function renderPrometheusMetrics(): string {
@@ -244,6 +319,49 @@ export function renderPrometheusMetrics(): string {
     lines.push(`llm_request_latency_seconds_count{model="${escapeLabelValue(model)}"} ${count}`)
   }
 
+  lines.push(
+    '# HELP blackice_preflight_total Total persisted preflight results by bounded outcome.',
+    '# TYPE blackice_preflight_total counter'
+  )
+
+  const sortedPreflightEntries = [...preflightCounters.entries()].sort(([a], [b]) =>
+    a.localeCompare(b)
+  )
+  for (const [key, value] of sortedPreflightEntries) {
+    const { outcome } = parsePreflightKey(key)
+    lines.push(`blackice_preflight_total{outcome="${escapeLabelValue(outcome)}"} ${value}`)
+  }
+
+  lines.push(
+    '# HELP blackice_execution_lifecycle_total Total execution lifecycle events by bounded stage, outcome, and reason.',
+    '# TYPE blackice_execution_lifecycle_total counter'
+  )
+
+  const sortedExecutionEntries = [...executionLifecycleCounters.entries()].sort(([a], [b]) =>
+    a.localeCompare(b)
+  )
+  for (const [key, value] of sortedExecutionEntries) {
+    const { stage, outcome, reason } = parseExecutionLifecycleKey(key)
+    lines.push(
+      `blackice_execution_lifecycle_total{stage="${escapeLabelValue(stage)}",outcome="${escapeLabelValue(outcome)}",reason="${escapeLabelValue(reason)}"} ${value}`
+    )
+  }
+
+  lines.push(
+    '# HELP blackice_repository_errors_total Total execution repository errors by bounded operation and storage kind.',
+    '# TYPE blackice_repository_errors_total counter'
+  )
+
+  const sortedRepositoryEntries = [...repositoryErrorCounters.entries()].sort(([a], [b]) =>
+    a.localeCompare(b)
+  )
+  for (const [key, value] of sortedRepositoryEntries) {
+    const { operation, storageKind } = parseRepositoryErrorKey(key)
+    lines.push(
+      `blackice_repository_errors_total{operation="${escapeLabelValue(operation)}",storage_kind="${escapeLabelValue(storageKind)}"} ${value}`
+    )
+  }
+
   return `${lines.join('\n')}\n`
 }
 
@@ -257,4 +375,7 @@ export function resetHttpMetrics(): void {
   llmDurationSums.clear()
   llmDurationCounts.clear()
   llmDurationBuckets.clear()
+  preflightCounters.clear()
+  executionLifecycleCounters.clear()
+  repositoryErrorCounters.clear()
 }

--- a/src/routes.integration.test.ts
+++ b/src/routes.integration.test.ts
@@ -1389,7 +1389,11 @@ describe('integration routes', () => {
     vi.stubEnv('METRICS_EXPOSE_PATH', '/metrics')
 
     const { createApp } = await import('./app.js')
-    const app = createApp(1)
+    const app = createApp(1, {
+      preflightEvaluator: {
+        evaluate: vi.fn().mockResolvedValue(buildPreflightResult(true)),
+      },
+    })
 
     const metricsRes = await request(app).get('/metrics')
     expect(metricsRes.status).toBe(200)
@@ -1399,9 +1403,30 @@ describe('integration routes', () => {
     const healthRes = await request(app).get('/healthz')
     expect(healthRes.status).toBe(200)
 
+    const submit = await request(app).post('/v1/intents').send({
+      idempotencyKey: 'idem-http-metrics',
+      accountId: 'acct-primary',
+      market: 'BTC-USD',
+      venue: 'paper',
+      side: 'buy',
+      quantity: 1,
+      notionalUsd: 1000,
+      ttlSeconds: 300,
+    })
+    const intentId = submit.body.intent.intentId
+    await request(app).post(`/v1/intents/${intentId}/confirm`).send({})
+    await request(app).post(`/v1/intents/${intentId}/preflight`).send({
+      candidate: buildEnrichedCandidate(),
+    })
+    await request(app).post(`/v1/intents/${intentId}/execute`).send({})
+
     const metricsAfterTraffic = await request(app).get('/metrics')
     expect(metricsAfterTraffic.text).toContain(
       'blackice_http_requests_total{route="/healthz",method="GET",status="200"} 1'
+    )
+    expect(metricsAfterTraffic.text).toContain('blackice_preflight_total{outcome="pass"} 1')
+    expect(metricsAfterTraffic.text).toContain(
+      'blackice_execution_lifecycle_total{stage="placement",outcome="filled",reason="venue_status"} 1'
     )
   })
 

--- a/src/routes/intents.ts
+++ b/src/routes/intents.ts
@@ -1,40 +1,41 @@
 import type { Express, Request, Response } from 'express'
 import { getRuntimeConfig } from '../config/runtimeConfig.js'
-import { log } from '../log.js'
-import { sendSimpleError } from '../http/errors.js'
-import { parseBodyOrRespond } from '../http/validation.js'
-import { getRequestId } from '../http/requestLogging.js'
+import {
+  type CandidateEnrichmentAdapter,
+  type PreflightEvaluator,
+  PreflightRequestSchema,
+} from '../execution/contracts.js'
 import { PublicCandidateDiscoveryAdapter } from '../execution/discovery.js'
 import { CandidateEnrichmentPipeline } from '../execution/enrichment.js'
 import { PublicOrderbookReadAdapter } from '../execution/orderbook.js'
 import { CandidatePreflightEngine } from '../execution/preflight.js'
 import {
-  ExecutionPolicyError,
-  ExecutionService,
-  IntentNotFoundError,
-  IntentStateError,
-} from '../execution/service.js'
-import {
-  IntentActionResponseSchema,
-  IntentStatusSchema,
   ExecuteIntentRequestSchema,
   ExecuteIntentResponseSchema,
-  IntentRefreshResponseSchema,
+  IntentActionResponseSchema,
   IntentExecutionLogsResponseSchema,
-  IntentPreflightResponseSchema,
   IntentPreflightHistoryResponseSchema,
-  ListCandidatesResponseSchema,
+  IntentPreflightResponseSchema,
+  IntentRefreshResponseSchema,
+  IntentStatusSchema,
   ListCandidatesRequestSchema,
+  ListCandidatesResponseSchema,
   ListIntentsResponseSchema,
   PreflightActionResponseSchema,
   SubmitIntentRequestSchema,
   SubmitIntentResponseSchema,
 } from '../execution/schema.js'
 import {
-  PreflightRequestSchema,
-  type CandidateEnrichmentAdapter,
-  type PreflightEvaluator,
-} from '../execution/contracts.js'
+  ExecutionPolicyError,
+  ExecutionService,
+  IntentNotFoundError,
+  IntentStateError,
+} from '../execution/service.js'
+import { sendSimpleError } from '../http/errors.js'
+import { recordExecutionLifecycle } from '../http/metrics.js'
+import { getRequestId } from '../http/requestLogging.js'
+import { parseBodyOrRespond } from '../http/validation.js'
+import { log } from '../log.js'
 
 type IntentRouteOptions = {
   candidateEnrichmentAdapter?: CandidateEnrichmentAdapter
@@ -249,6 +250,7 @@ export function registerIntentRoutes(
         ? executionService.getExecutionPreflightRecord(req.params.intentId)
         : null
       if (requirePreflightExecution() && !preflightRecord) {
+        recordExecutionLifecycle('preflight_gate', 'blocked', 'preflight_required')
         res.status(422).json({
           error: 'Preflight is required before execution',
           code: 'preflight_required',


### PR DESCRIPTION
Closes #178

## Prod-readiness objective
Expose bounded-label Prometheus metrics for production operational signals around persisted preflights, execution lifecycle transitions, refresh failures, repository errors, and existing model request metrics.

## Files touched
- `src/http/metrics.ts`
- `src/http/metrics.test.ts`
- `src/execution/service.ts`
- `src/execution/repository.ts`
- `src/routes/intents.ts`
- `src/routes.integration.test.ts`

## Tests run
- `pnpm exec vitest run src/http/metrics.test.ts src/routes.integration.test.ts src/execution/service.test.ts src/execution/repository.test.ts`
- `pnpm exec biome check src/http/metrics.ts src/http/metrics.test.ts src/execution/service.ts src/execution/repository.ts src/routes/intents.ts src/routes.integration.test.ts`
- `pnpm run build`

## Rollout notes
- Adds `blackice_preflight_total`, `blackice_execution_lifecycle_total`, and `blackice_repository_errors_total`.
- Labels are bounded to outcome/stage/reason/storage operation values; no request IDs, user text, market IDs, or intent IDs are emitted.
- Existing HTTP and LLM metrics remain compatible.

## Out of scope
- Alert rule definitions
- Dashboard configuration
- Background polling or execution behavior changes
- Runbook documentation
